### PR TITLE
Improvement for the available translations listed on each readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 This repository contains all the source code, tutorials, and examples from the [Platform Engineering on Kubernetes](https://www.salaboy.com/book/) Book.
 
-## Chapters
+## K8s Tutorials
 
-Each chapter of the book refers to a step-by-step tutorial that you can run to get your hands dirty with some Open Source projects. 
+_Available in_: [English](README.md) | [中文 (Chinese)](README.zh-cn.md) | [Português (Portuguese)](README.zh-cn.md)
+> **Note:** Such language diversity is brought to you by [contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors) from a fantastic cloud-native community.  Huge thanks! 🚀
+
+Each chapter of the book refers to a step-by-step tutorial that you can run to get your hands dirty with some Open Source projects.
 
 - [Chapter 1: (The Rise of) Platforms on Top of Kubernetes](chapter-1/README.md)
 - [Chapter 2: Cloud-Native Application Challenges](chapter-2/README.md)
@@ -12,20 +15,17 @@ Each chapter of the book refers to a step-by-step tutorial that you can run to g
 - [Chapter 4: Environment Pipelines: Deploying Cloud-Native applications](chapter-4/README.md)
 - [Chapter 5: Multi-Cloud (App) infrastructure](chapter-5/README.md)
 - [Chapter 6: Let's Build a Platform on Top of Kubernetes](chapter-6/README.md)
-- [Chapter 7: Platform Capabilities I: Shared Application Concerns](chapter-7/README.md) 
-- [Chapter 8: Platform Capabilities II: Enabling Teams to Experiment](chapter-8/README.md) 
-- [Chapter 9: Measure your Platforms](chapter-9/README.md) 
+- [Chapter 7: Platform Capabilities I: Shared Application Concerns](chapter-7/README.md)
+- [Chapter 8: Platform Capabilities II: Enabling Teams to Experiment](chapter-8/README.md)
+- [Chapter 9: Measure your Platforms](chapter-9/README.md)
 
-## Translations
 
-Thanks to the fantastic cloud-native community, you can read these tutorials in the following languages:
-- [Chinese `zh-cn`](README.zh-cn.md) :cn:
+Next, you can find information about the application used in the tutorials and mentioned on the book.
 
 ## Code
 
-The code for the Conference Application (walking skeleton) and other related artifacts, such as Helm charts and configuration files, can be found inside the [conference-application](conference-application/README.md) directory. All these examples can be built from source, and I encourage you to explore and change these applications. 
+The code for the Conference Application (walking skeleton) and other related artifacts, such as Helm charts and configuration files, can be found inside the [conference-application](conference-application/README.md) directory. All these examples can be built from source, and I encourage you to explore and change these applications.
 
 ## Comments / Suggestions / Questions
 
-If you have any comments, suggestions, or questions please open an issue, drop me a comment on my blog [https://www.salaboy.com](https://www.salaboy.com), or contact me via [Twitter @Salaboy](https://twitter.com/salaboy)
-
+If you have any comments, suggestions, or questions please [open an issue](https://github.com/salaboy/platforms-on-k8s/issues/new), drop me a comment on my blog [https://www.salaboy.com](https://www.salaboy.com), or contact me via [Twitter @Salaboy](https://twitter.com/salaboy).

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 This repository contains all the source code, tutorials, and examples from the [Platform Engineering on Kubernetes](https://www.salaboy.com/book/) Book.
 
+---
+
 ## K8s Tutorials
 
-_Available in_: [English](README.md) | [中文 (Chinese)](README.zh-cn.md) | [Português (Portuguese)](README.zh-cn.md)
+_Available in_: [English](README.md) | [中文 (Chinese)](README.zh-cn.md) | [Português (Portuguese)](README-pt.md)
 > **Note:** Such language diversity is brought to you by [contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors) from a fantastic cloud-native community.  Huge thanks! 🚀
 
 Each chapter of the book refers to a step-by-step tutorial that you can run to get your hands dirty with some Open Source projects.

--- a/chapter-2/README.md
+++ b/chapter-2/README.md
@@ -1,13 +1,16 @@
 # Chapter 2 :: Cloud-Native Application Challenges
 
+---
+_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README.zh-cn.md) 
+> **Note:** Brought to you by the fantastic cloud-native community's [ 🌟 contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
+
+---
 In this short tutorial, we will be installing the `Conference Application` using Helm into a local KinD Kubernetes Cluster. 
 
 Helm Charts can be published to Helm Chart repositories or also, since Helm 3.7 as OCI containers to container registries. 
 
 Check the pre-requisites for all the tutorials [here](../chapter-1/README.md#pre-requisites-for-the-other-chapters)
 
-Thanks to the fantastic cloud-native community, you can read these tutorials in the following languages:
-- [Chinese `zh-cn`](README.zh-cn.md) :cn:
 
 ## Creating a local cluster with Kubernetes KinD
 

--- a/chapter-3/README.md
+++ b/chapter-3/README.md
@@ -1,13 +1,17 @@
 # Service Pipelines
 
+---
+_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README.zh-cn.md)
+> **Note:** Brought to you by the fantastic cloud-native community's [ 🌟 contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
+
+---
+
 These short tutorials cover both Tekton and Dagger for Service Pipelines. With Tekton we extend the Kubernetes APIs to define our Pipelines and Tasks. With Dagger we programatically define Pipelines that can be executed remotely in Kubernentes or locally in our development laptops. Finally, a pointer to a set of GitHub Actions is provided to be able to compare between these different approaches.
 
 - [Tekton for Service Pipelines Tutorial](tekton/README.md)
 - [Dagger for Service Pipelines Tutorial](dagger/README.md)
 - [GitHub Actions](github-actions/README.md)
 
-Thanks to the fantastic cloud-native community, you can read these tutorials in the following languages:
-- [Chinese zh-cn](README.zh-cn.md) 🇨🇳
 
 ## Clean up
 

--- a/chapter-4/README.md
+++ b/chapter-4/README.md
@@ -1,5 +1,11 @@
 # Environment Pipelines
 
+---
+_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README.zh-cn.md)
+> **Note:** Brought to you by the fantastic cloud-native community's [ 🌟 contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
+
+---
+
 In this short tutorial we will set up our Staging Environment Pipeline using [ArgoCD](https://argo-cd.readthedocs.io/en/stable/). We will configure the environment to contain an instance of the Conference Application.
 
 We will define the configuration of Staging environment using a Git repository. The [`argo-cd/staging` directory](argo-cd/staging/) contains the definition of a Helm chart that can be synced to multiple Kubernetes Clusters. 

--- a/chapter-5/README.md
+++ b/chapter-5/README.md
@@ -1,5 +1,12 @@
 # Multi-Cloud (App) Infrastructure
 
+---
+_🌍 Available in_: [English](README.md)
+
+> **Note:** Brought to you by the fantastic cloud-native community's [ 🌟 contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
+
+---
+
 In this step-by-step tutorial, we will be using Crossplane to Provision the Redis, PostgreSQL and Kafka instances for our application services to use. 
 
 By using Crossplane and Crossplane Compositions, we aim to unify how these components are provisioned, hiding away where these components are for the end users (application teams).

--- a/chapter-6/README.md
+++ b/chapter-6/README.md
@@ -1,5 +1,13 @@
 # Chpater 6 :: Let's build a Platform on top of Kubernetes
 
+---
+_🌍 Available in_: [English](README.md)
+
+> **Note:** Brought to you by the fantastic cloud-native community's [ 🌟 contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
+
+---
+
+
 On this step-by-step tutorial we will create the APIs of our platform by reusing the power of the Kubernetes APIs. The first use case where the platform can assist the development teams is by creating new development environments providing a self-service approach. 
 
 To build this example we will be using Crossplane and `vcluster`, two Open Source projects hosted in the Cloud-Native Computing Foundation. 

--- a/chapter-7/README.md
+++ b/chapter-7/README.md
@@ -1,5 +1,12 @@
 # Chapter 7 :: Shared Applications Concerns
 
+---
+_🌍 Available in_: [English](README.md)
+
+> **Note:** Brought to you by the fantastic cloud-native community's [ 🌟 contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
+
+---
+
 On this step-by-step tutorials we will look into how to use [Dapr](https://dapr.io) to provide Application-level APIs to solve common challenges that most Distributed Applications will face. 
 
 Then we will look at [OpenFeature](https://openfeature.dev) a project that aims to standardize Feature Flags, so developement teams can keep releasing new features and stakeholders can decide when to enable/disable these features for their customers. 

--- a/chapter-8/README.md
+++ b/chapter-8/README.md
@@ -1,5 +1,12 @@
 # Chapter 8 :: Enabling Teams to Experiment
 
+---
+_🌍 Available in_: [English](README.md)
+
+> **Note:** Brought to you by the fantastic cloud-native community's [ 🌟 contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
+
+---
+
 In these tutorials you will install Knative Serving and Argo Rollouts on a Kubernetes cluster to implement Canary Releases, A/B testing and Blue/Green Deployments. The release strategies discussed here aim to enable teams to have more control when releasing new versions of their services. By applying different techniques when releasing software, teams can experiment and test their new versions in a controlled setup, without pushing all the live traffic to a new version at a single point in time. 
 
 - [Release Strategies using Knative Serving](knative/README.md)

--- a/chapter-9/README.md
+++ b/chapter-9/README.md
@@ -1,5 +1,12 @@
 # Chapter 9 :: Measuring your Platforms
 
+---
+_🌍 Available in_: [English](README.md)
+
+> **Note:** Brought to you by the fantastic cloud-native community's [ 🌟 contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
+
+---
+
 This chapter cover two different tutorials on how to use DORA metrics to measure your platform initiative performances. 
 
 - [DORA metrics and CloudEvents](dora-cloudevents/README.md)


### PR DESCRIPTION
# Changes
Related to #32 
- :broom: List of available translations 
- :broom: Adjustments of the headings structures on the main readme 

/kind cleanup 

**Release Note**

```release-note
- The list of available translations is now cleaner and won't occupy to much space when the list of options grow
- Standardized across all english files
- Instead of using, for instance, `pt-BR`, each link is now written on the referred language `Português (Portuguese)`
- Link to the list of contributors added on every reference of the translation's contributions. 
- The translations section was added to every chapter to facilitate the inclusion of incoming new languages added by contributors.
```

