### PR TITLE
Code snippets type adjustment on all chapters

### DIFF
--- a/chapter-2/README.md
+++ b/chapter-2/README.md
@@ -13,7 +13,7 @@ Thanks to the fantastic cloud-native community, you can read these tutorials in 
 
 Create a KinD Cluster with three worker nodes and 1 Control Plane.
 
-```
+```shell
 cat <<EOF | kind create cluster --name dev --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
@@ -48,7 +48,7 @@ The idea here is to optimize the process for our Cluster, so when we install the
 
 Run the script by copying this command into your terminal from inside the `chapter-2` directory: 
 
-```
+```shell
 ./kind-load.sh
 ```
 
@@ -58,7 +58,7 @@ By running this script, you will fetch all the required images and then load the
 > [!Note]
 > If you are running Docker Desktop on MacOS and have set a smaller size for the virtual disk, you may encounter the following error:
 >
-> ```bash
+> ```shell
 > $ ./kind-load.sh
 > ...
 > Command Output: Error response from daemon: write /var/lib/docker/...
@@ -73,12 +73,12 @@ By running this script, you will fetch all the required images and then load the
 
 We need the NGINX Ingress Controller to route traffic from our laptop to the services running inside the cluster. NGINX Ingress Controller acts as a router that is running inside the cluster but exposed to the outside world. 
 
-```
+```shell
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/release-1.8/deploy/static/provider/kind/deploy.yaml
 ```
 
 Check that the pods inside the `ingress-nginx` are started correctly before proceeding: 
-```
+```shell
 > kubectl get pods -n ingress-nginx
 NAME                                        READY   STATUS      RESTARTS   AGE
 ingress-nginx-admission-create-cflcl        0/1     Completed   0          62s
@@ -87,7 +87,7 @@ ingress-nginx-controller-5bb6b499dc-7chfm   0/1     Running     0          62s
 ```
 
 This allows you to route traffic from `http://localhost` to services inside the cluster. Notice that for KinD to work in this way, when we created the cluster we provided extra parameters and labels for the control plane node:
-```
+```yaml
 nodes:
 - role: control-plane
   kubeadmConfigPatches:
@@ -112,13 +112,13 @@ Once we have our cluster and our Ingress Controller installed and configured, we
 
 From Helm 3.7+, we can use OCI images to publish, download, and install Helm Charts. This approach uses Docker Hub as a Helm Chart registry, and to install the Conference Application, you only need to run the following command:
 
-```
+```shell
 helm install conference oci://docker.io/salaboy/conference-app --version v1.0.0
 ```
 
 You can also run the following command to see the details of the chart: 
 
-```
+```shell
 helm show all oci://docker.io/salaboy/conference-app --version v1.0.0
 ```
 
@@ -126,7 +126,7 @@ Check that all the application pods are up and running. Notice that if your inte
 
 Eventually, you should see something like this, It can take a few minutes: 
 
-```
+```shell
 kubectl get pods
 NAME                                                           READY   STATUS    RESTARTS      AGE
 conference-agenda-service-deployment-7cc9f58875-k7s2x          1/1     Running   4 (45s ago)   2m2s
@@ -151,13 +151,13 @@ Because the Conference Application is installing PostgreSQL, Redis, and Kafka, i
 
 You can delete all PVCs by listing them with:
 
-```
+```shell
 kubectl get pvc
 ```
 
 You should see:
 
-```
+```shell
 NAME                                   STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
 data-conference-kafka-0                Bound    pvc-2c3ccdbe-a3a5-4ef1-a69a-2b1022818278   8Gi        RWO            standard       8m13s
 data-conference-postgresql-0           Bound    pvc-efd1a785-e363-462d-8447-3e48c768ae33   8Gi        RWO            standard       8m13s
@@ -165,7 +165,7 @@ redis-data-conference-redis-master-0   Bound    pvc-5c2a96b1-b545-426d-b800-b8c7
 ```
 
 And then delete with: 
-```
+```shell
 kubectl delete pvc  data-conference-kafka-0 data-conference-postgresql-0 redis-data-conference-redis-master-0
 ```
 
@@ -173,7 +173,7 @@ The name of the PVCs will change based on the Helm Release name that you used wh
 
 Finally, if you want to get rid of the KinD Cluster entirely, you can run:
 
-```
+```shell
 kind delete clusters dev
 ```
 

--- a/chapter-2/README.md
+++ b/chapter-2/README.md
@@ -54,17 +54,20 @@ Run the script by copying this command into your terminal from inside the `chapt
 
 By running this script, you will fetch all the required images and then load them into every node of your KinD cluster. If you are running the examples on a Cloud Provider, this might not be worth it as Cloud Providers with Gigabyte connections to container registries might fetch these images in a matter of seconds.
 
-**Note:** If you are running Docker Desktop on MacOS and have set a smaller size for the virtual disk, you may encounter the following error:
 
-```
-$ ./kind-load.sh
-...
-Command Output: Error response from daemon: write /var/lib/docker/.../layer.tar: no space left on device
-```
+> [!Note]
+> If you are running Docker Desktop on MacOS and have set a smaller size for the virtual disk, you may encounter the following error:
+>
+> ```bash
+> $ ./kind-load.sh
+> ...
+> Command Output: Error response from daemon: write /var/lib/docker/...
+> /layer.tar: no space left on device
+> ```
+>
+> You can modify the value of the Virtual Disk limit in the ``Settings -> Resources`` menu.
+>   ![MacOS Docker Desktop virtual disk limits](imgs/macos-docker-desktop-virtual-disk-setting.png)
 
-You can modify the value of the Virtual Disk limit in the ``Settings -> Resources`` menu.
-
-![MacOS Docker Desktop virtual disk limits](imgs/macos-docker-desktop-virtual-disk-setting.png)
 
 ### Installing NGINX Ingress Controller
 

--- a/chapter-3/README.md
+++ b/chapter-3/README.md
@@ -13,7 +13,7 @@ Thanks to the fantastic cloud-native community, you can read these tutorials in 
 
 If you want to get rid of the KinD Cluster created for these tutorials, you can run:
 
-```
+```shell
 kind delete clusters dev
 ```
 

--- a/chapter-3/dagger/README.md
+++ b/chapter-3/dagger/README.md
@@ -19,7 +19,7 @@ You can clone this repository and from the [Confernece Application directory](..
 
 You can run any defined task inside the `service-pipeline.go` file:
 
-```
+```shell
 go mod tidy
 go run service-pipeline.go build <SERVICE DIRECTORY>
 ```
@@ -33,7 +33,7 @@ If you run `go run service-pipeline.go all notifications-service v1.0.0-dagger` 
 
 You can safely run `go run service-pipeline.go build notifications-service` which doesn't require you to set any credentials. You can set up your container registry and username using envorionment variables, for example: 
 
-```
+```shell
 CONTAINER_REGISTRY=<YOUR_REGISTRY> CONTAINER_REGISTRY_USER=<YOUR_USER> go run service-pipeline.go publish notifications-service v1.0.0-dagger
 ```
 This require you to be logged in to the registry where you want to publish your container images to.
@@ -51,18 +51,18 @@ In this short tutorial we will run the pipelines that we were running locally wi
 
 Let's run the Dagger Pipeline Engine inside Kubernetes by creating a Pod with Dagger: 
 
-```
+```shell
 kubectl run dagger --image=registry.dagger.io/engine:v0.3.13 --privileged=true
 ```
 
 Alternatively, you can apply the `chapter-3/dagger/k8s/pod.yaml` manifest using `kubectl apply -f chapter-3/dagger/k8s/pod.yaml`.
 
 Check that the `dagger`` pod is running: 
-```
+```shell
 kubectl get pods 
 ```
 You should see something like this: 
-```
+```shell
 NAME     READY   STATUS    RESTARTS   AGE
 dagger   1/1     Running   0          49s
 ```
@@ -70,30 +70,30 @@ dagger   1/1     Running   0          49s
 **Note**: this is far from ideal because we are not setting any persistence or replication mechanism for Dagger itself, all the caching mechanism are volatile in this case. Check the official documentation for more about this. 
 
 Now to run the projects pipelines against this remote service you only need to export the following environment variable: 
-```
+```shell
 export _EXPERIMENTAL_DAGGER_RUNNER_HOST=kube-pod://<podname>?context=<context>&namespace=<namespace>&container=<container>
 ```
 
 Where `<podname>` is `dagger` (because we created the pod manually), `<context>` is your Kubernetes Cluster context, if you are running against a KinD Cluster this might be `kind-dev`. You can find your current context name by running `kubectl config current-context`. Finally `<namespace>` is the namespace where you run the Dagger Container, and `<container>` is once again `dagger`. For my setup against KinD, this would look like this: 
 
-```
+```shell
 export _EXPERIMENTAL_DAGGER_RUNNER_HOST="kube-pod://dagger?context=kind-dev&namespace=default&container=dagger"
 ```
 
 Notice also that my KinD cluster (named `kind-dev`) didn't had anything related to Pipelines. 
 
 Now if you run in any of the projects: 
-```
+```shell
 go run service-pipeline.go build notifications-service
 ```
 Or to test your service remotly: 
 
-```
+```shell
 go run service-pipeline.go test notifications-service
 ```
 
 In a separate tab you can tail the logs from the Dagger engine by running: 
-```
+```shell
 kubectl logs -f dagger
 ```
 

--- a/chapter-4/README.md
+++ b/chapter-4/README.md
@@ -15,14 +15,14 @@ We will define the configuration of Staging environment using a Git repository. 
 
 Once you have the cluster up and running with the nginx-ingress controller, let's install Argo CD in the cluster: 
 
-```
+```shell
 kubectl create namespace argocd
 kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
 ```
 
 You should see something like this: 
 
-```
+```shell
 > kubectl create namespace argocd
 kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
 namespace/argocd created
@@ -86,7 +86,7 @@ networkpolicy.networking.k8s.io/argocd-server-network-policy created
 
 You can access the ArgoCD User Interface by using port-forward, in a **new terminal** run:
 
-```
+```shell
 kubectl port-forward svc/argocd-server -n argocd 8080:443
 ```
 
@@ -106,7 +106,7 @@ That should take you to the Login Page:
 
 The user is `admin`, and to get the password for the ArgoCD Dashboard by running: 
 
-```
+```shell
 kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d; echo
 ```
 
@@ -123,13 +123,13 @@ For this tutorial we will use a single namespace to represent our Staging Enviro
 
 First let's create a namespace for our Staging Environment:
 
-```
+```shell
 kubectl create ns staging
 ```
 
 You should see something like this: 
 
-```
+```shell
 > kubectl create ns staging
 namespace/staging created
 ```
@@ -168,7 +168,7 @@ You can expand the app by clicking on it to see the full view of all the resourc
 
 If you are running in a local environment, you can always access the application using `port-forward`, in a **new terminal** run:
 
-```
+```shell
 kubectl port-forward svc/frontend -n staging 8081:80
 ```
 
@@ -179,13 +179,13 @@ Wait for the applicatons pod to be up and running and then you can access the ap
 
 As usual, you can monitor the status of the pods and services using `kubectl`. To check if the application pods are ready you can run: 
 
-```
+```shell
 kubectl get pods -n staging
 ```
 
 You should see something like this: 
 
-```
+```shell
 > kubectl get pods -n staging
 NAME                                                              READY   STATUS    RESTARTS        AGE
 stating-environment-agenda-service-deployment-6c9cbb9695-xj99z    1/1     Running   5 (6m ago)      8m4s
@@ -215,7 +215,7 @@ Go ahead and edit the Application Details / Parameters and select `values-debug-
 
 Because we were using port-forwarding, you might need to run this command again: 
 
-```
+```shell
 kubectl port-forward svc/frontend -n staging 8081:80
 ```
 
@@ -229,7 +229,7 @@ Once the frontend is up and running you should see the Debug tab in the Back Off
 
 If you want to get rid of the KinD Cluster created for this tutorial, you can run:
 
-```
+```shell
 kind delete clusters dev
 ```
 

--- a/chapter-5/README.md
+++ b/chapter-5/README.md
@@ -13,8 +13,7 @@ To install Crossplane you need to have a Kubernetes Cluster, you can create one 
 
 Let's install [Crossplane](https://crossplane.io) into its own namespace using Helm: 
 
-```
-
+```shell
 helm repo add crossplane-stable https://charts.crossplane.io/stable
 helm repo update
 
@@ -23,31 +22,31 @@ helm install crossplane --namespace crossplane-system --create-namespace crosspl
 
 Install the `kubectl crossplane` plugin: 
 
-```
+```shell
 curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | sh
 sudo mv kubectl-crossplane /usr/local/bin
 ```
 
 Then install the Crossplane Helm provider: 
-```
+```shell
 kubectl crossplane install provider crossplane/provider-helm:v0.10.0
 ```
 
 We need the correct `ServiceAccount` to create a new `ClusterRoleBinding` so the Helm Provider can install Charts on our behalf. 
 
-```
+```shell
 SA=$(kubectl -n crossplane-system get sa -o name | grep provider-helm | sed -e 's|serviceaccount\/|crossplane-system:|g')
 kubectl create clusterrolebinding provider-helm-admin-binding --clusterrole cluster-admin --serviceaccount="${SA}"
 ```
 
-```
+```shell
 kubectl apply -f crossplane/helm-provider-config.yaml
 ```
 
 
 After a few seconds, if you check the configured providers, you should see the Helm `INSTALLED` and `HEALTHY`: 
 
-```
+```shell
 > kubectl get providers.pkg.crossplane.io
 NAME                             INSTALLED   HEALTHY   PACKAGE                               AGE
 crossplane-provider-helm         True        True      crossplane/provider-helm:v0.10.0      49s
@@ -60,7 +59,7 @@ Now we are ready to install our Databases and Message Brokers Crossplane composi
 
 We need to install our Crossplane Compositions for our Key-Value Database (Redis), our SQL Database (PostgreSQL) and our Message Broker(Kafka). 
 
-```
+```shell
 kubectl apply -f resources/
 ```
 
@@ -73,13 +72,13 @@ Check the [resources/](resources/) directory for the Compositions and the Compos
 
 We can provision a new Key-Value Database for our team to use by executing the following command: 
 
-```
+```shell
 kubectl apply -f my-db-keyvalue.yaml
 ```
 
 The `my-db-keyvalue.yaml` resource looks like this: 
 
-```
+```yaml
 apiVersion: salaboy.com/v1alpha1
 kind: Database
 metadata:
@@ -98,7 +97,7 @@ Notice that we are using the labels `provider: local`, `type: dev` and `kind: ke
 
 You can check the database status using:
 
-```
+```shell
 > kubectl get dbs
 NAME              SIZE    MOCKDATA   KIND       SYNCED   READY   COMPOSITION                     AGE
 my-db-keyavalue   small   false      keyvalue   True     True    keyvalue.db.local.salaboy.com   97s
@@ -108,13 +107,13 @@ You can check that a new Redis instance was created in the `default` namespace.
 
 You can follow the same steps to provision a PostgreSQL database by running: 
 
-```
+```shell
 kubectl apply -f my-db-sql.yaml
 ```
 
 You should see now two `dbs`
 
-```
+```shell
 > kubectl get dbs
 NAME              SIZE    MOCKDATA   KIND       SYNCED   READY   COMPOSITION                     AGE
 my-db-keyavalue   small   false      keyvalue   True     True    keyvalue.db.local.salaboy.com   2m
@@ -124,7 +123,7 @@ my-db-sql         small   false      sql        True     False   sql.db.local.sa
 
 You can now check that there are two Pods running, one for each database:
 
-```
+```shell
 > kubectl get pods
 NAME                             READY   STATUS    RESTARTS   AGE
 my-db-keyavalue-redis-master-0   1/1     Running   0          3m40s
@@ -133,7 +132,7 @@ my-db-sql-postgresql-0           1/1     Running   0          104s
 
 And there should be 4 Kubernetes Secrets (two for our two helm releases and two containing the credentials to connect to the newly created instances):
 
-```
+```shell
 > kubectl get secret
 NAME                                    TYPE                 DATA   AGE
 my-db-keyavalue-redis                   Opaque               1      2m32s
@@ -144,13 +143,13 @@ sh.helm.release.v1.my-db-sql.v1         helm.sh/release.v1   1      36s
 
 We can do the same to provision a new instance of our Kafka Message Broker: 
 
-```
+```shell
 kubectl apply -f my-messagebroker-kafka.yaml
 ```
 
 And then list with: 
 
-```
+```shell
 > kubectl get mbs
 NAME          SIZE    KIND    SYNCED   READY   COMPOSITION                  AGE
 my-mb-kafka   small   kafka   True     True    kafka.mb.local.salaboy.com   2m51s
@@ -160,7 +159,7 @@ Kafka doesn't require any secret to be created when using its default configurat
 
 You should see three running pods (one for Kafka, one for Redis and one for PostgreSQL).
 
-```
+```shell
 > kubectl get pods
 NAME                             READY   STATUS    RESTARTS   AGE
 my-db-keyavalue-redis-master-0   1/1     Running   0          113s
@@ -178,12 +177,12 @@ Ok, now that we have our two databases and our message broker running, we need t
 
 For that, we will use the `app-values.yaml` file containing the configurations for the services to connect to our newly created databases:
 
-```
+```shell
 helm install conference oci://registry-1.docker.io/salaboy/conference-app --version v1.0.0 -f app-values.yaml
 ```
 
 The `app-values.yaml` content looks like this: 
-```
+```yaml
 install:
   infrastructure: false
 frontend:
@@ -216,7 +215,7 @@ If you made it this far, you can now provision multi-cloud infrastructure by usi
 
 If you want to get rid of the KinD Cluster created for this tutorial, you can run:
 
-```
+```shell
 kind delete clusters dev
 ```
 

--- a/chapter-5/aws/README.md
+++ b/chapter-5/aws/README.md
@@ -9,8 +9,7 @@ To install Crossplane you need to have a Kubernetes Cluster, you can create one 
 
 Let's install [Crossplane](https://crossplane.io) into its own namespace using Helm: 
 
-```
-
+```shell
 helm repo add crossplane-stable https://charts.crossplane.io/stable
 helm repo update
 
@@ -19,19 +18,19 @@ helm install crossplane --namespace crossplane-system --create-namespace crosspl
 
 Install the `kubectl crossplane` plugin: 
 
-```
+```shell
 curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | sh
 sudo mv kubectl-crossplane /usr/local/bin
 ```
 
 Then install the Crossplane AWS provider: 
-```
+```shell
 kubectl crossplane install provider crossplane/provider-aws:v0.21.2
 ```
 
 After a few seconds, if you check the configured providers, you should see the Helm `INSTALLED` and `HEALTHY`: 
 
-```
+```shell
 > kubectl get providers.pkg.crossplane.io
 NAME                             INSTALLED   HEALTHY   PACKAGE                               AGE
 crossplane-provider-aws         True        True      crossplane/provider-aws:v0.21.2       49s
@@ -43,7 +42,7 @@ Now we are ready to install our Databases and Message Brokers Crossplane composi
 
 We need to install our Crossplane Compositions for our Key-Value Database (Redis), our SQL Database (PostgreSQL) and our Message Broker(Kafka). 
 
-```
+```shell
 kubectl apply -f resources/
 ```
 
@@ -53,7 +52,7 @@ Check the [resources/](resources/) directory for the Compositions and the Compos
 
 Create a text file containing the AWS account aws_access_key_id and aws_secret_access_key.
 
-```
+```text
 [default]
 aws_access_key_id = 
 aws_secret_access_key = 
@@ -61,7 +60,7 @@ aws_secret_access_key =
 
 Create a Kubernetes secret with the AWS credentials 
 
-```
+```shell
 kubectl create secret \
 generic aws-secret \
 -n crossplane-system \
@@ -70,7 +69,7 @@ generic aws-secret \
 
 Create a ProviderConfig 
 
-```
+```shell
 cat <<EOF | kubectl apply -f -
 apiVersion: aws.upbound.io/v1beta1
 kind: ProviderConfig
@@ -90,7 +89,7 @@ EOF
 
 We can provision a new Key-Value Database for our team to use by executing the following commands to create all the infrastructure necessary: 
 
-```
+```shell
 kubectl apply -f my-db-keyvalue.yaml
 kubectl apply -f my-db-sql.yaml
 kubectl apply -f aws-messagebroker-kafka.yaml
@@ -102,14 +101,14 @@ Ok, now that we have our two databases and our message broker running, we need t
 
 For that, we will use the `app-values.yaml` file containing the configurations for the services to connect to our newly created databases:
 
-```
+```shell
 helm install conference oci://registry-1.docker.io/salaboy/conference-app --version v1.0.0 -f app-values.yaml
 ```
 
 Make sure to fill in the commented out aspects of the yaml file based off values from newly created AWS infrastructure.
 
 The `app-values.yaml` content looks like this: 
-```
+```shell
 install:
   infrastructure: false
 frontend:

--- a/chapter-7/README.md
+++ b/chapter-7/README.md
@@ -12,7 +12,7 @@ Because both projects are focused on providing developers new APIs and tools to 
 You need a Kubernetes Cluster to install [Dapr](https://dapr.io) and `flagd` an [OpenFeature](https://openfeature.dev/) Provider. You can create one using Kubernetes KinD as we did in [Chapter 2](https://github.com/salaboy/platforms-on-k8s/blob/main/chapter-2/README.md#creating-a-local-cluster-with-kubernetes-kind)
 
 Then you can install Dapr into the cluster by running: 
-```
+```shell
 helm repo add dapr https://dapr.github.io/helm-charts/
 helm repo update
 helm upgrade --install dapr dapr/dapr \
@@ -29,7 +29,7 @@ Once Dapr is installed, we can install our Dapr-Enabled and FeatureFlag-Enabled 
 
 Now you can install v2.0.0 of the application by running: 
 
-```
+```shell
 helm install conference oci://docker.io/salaboy/conference-app --version v2.0.0
 ```
 
@@ -39,7 +39,7 @@ This version of the Helm Chart installs the same application infrastructure as v
 
 In version `v2.0.0`, if you list the Application pods now, you will see that each service (agenda, c4p, frontend and notifications) has a Dapr Sidecar (`daprd`) running alongside the service container (READY 2/2): 
 
-```
+```shell
 > kubectl get pods
 NAME                                                           READY   STATUS    RESTARTS      AGE
 conference-agenda-service-deployment-5dd4bf67b-qkctd           2/2     Running   7 (7s ago)    74s
@@ -62,7 +62,7 @@ The Dapr Sidecar expose the Dapr Commponents APIs to enable the application to i
 
 You can list Dapr Components by running: 
 
-```
+```shell
 > kubectl get components
 NAME                                   AGE
 conference-agenda-service-statestore   30m
@@ -70,7 +70,7 @@ conference-conference-pubsub           30m
 ```
 
 You can describe each component to see its configurations:
-```
+```shell
 > kubectl describe component conference-agenda-service-statestore
 Name:         conference-agenda-service-statestore
 Namespace:    default
@@ -106,7 +106,7 @@ You can see that the Statestore component is connecting to the Redis instance ex
 
 Similarly, the PubSub Dapr Component that is connecting to Kafka: 
 
-```
+```shell
 kubectl describe component conference-conference-pubsub 
 Name:         conference-conference-pubsub
 Namespace:    default
@@ -133,14 +133,14 @@ Events:     <none>
 
 The final piece of the puzzle that allows the Frontend service to receive events that are submitted to the PubSub component is the following Dapr Subscription: 
 
-```
+```shell
 > kubectl get subscription
 NAME                               AGE
 conference-frontend-subscritpion   39m
 ```
 
 You can also describe this resource to see its configurations: 
-```
+```shell
 > kubectl describe subscription conference-frontend-subscritpion
 Name:         conference-frontend-subscritpion
 Namespace:    default
@@ -182,7 +182,7 @@ Finally, because this is all about enabling developers with Application Level AP
 
 When the Agenda Service wants to store or read data from the Dapr Statestore component it can use the Dapr Client to perform these operations, for example [reading values from the Statestore looks like this](https://github.com/salaboy/platforms-on-k8s/blob/v2.0.0/conference-application/agenda-service/agenda-service.go#L136C2-L136C116): 
 
-```
+```golang
 agendaItemsStateItem, err := s.APIClient.GetState(ctx, STATESTORE_NAME, fmt.Sprintf("%s-%s", TENANT_ID, KEY), nil)
 ```
 
@@ -192,7 +192,7 @@ All the application needs to know is the Statestore name (`STATESTORE_NAME`) and
 
 When the application wants to [store state into the Statestore it looks like this](https://github.com/salaboy/platforms-on-k8s/blob/v2.0.0/conference-application/agenda-service/agenda-service.go#L197C2-L199C3):
 
-```
+```golang
 if err := s.APIClient.SaveState(ctx, STATESTORE_NAME, fmt.Sprintf("%s-%s", TENANT_ID, KEY), jsonData, nil); err != nil {
 		...
 }
@@ -200,7 +200,7 @@ if err := s.APIClient.SaveState(ctx, STATESTORE_NAME, fmt.Sprintf("%s-%s", TENAN
 
 Finally, if the application code wants to [publish a new event to the PubSub component](https://github.com/salaboy/platforms-on-k8s/blob/v2.0.0/conference-application/agenda-service/agenda-service.go#L225), it will look like this: 
 
-```
+```golang
 if err := s.APIClient.PublishEvent(ctx, PUBSUB_NAME, PUBSUB_TOPIC, eventJson); err != nil {
 			...
 }
@@ -226,13 +226,13 @@ In the same way as Dapr APIs, the idea here is to have a consistent experience n
 
 You can get the flag configuration json file included in the ConfigMap by running: 
 
-```
+```shell
 kubectl get cm flag-configuration -o go-template='{{index .data "flag-config.json"}}'
 ```
 
 You should see the following output: 
 
-```
+```json
 {
   "flags": {
     "debugEnabled": {
@@ -283,13 +283,13 @@ There are three feature flags defined for this example:
 
 
 You can patch the ConfigMap to turn on the debug feature by following these steps. First fetch the content of the `flag-config.json` file located inside the ConfigMap and store it locally.
-```
+```shell
 kubectl get cm flag-configuration -o go-template='{{index .data "flag-config.json"}}' > flag-config.json
 ```
 
 Modify the content of this file, for example turn on the debug flag: 
 
-```
+```json
 {
   "flags": {
     "debugEnabled": {
@@ -304,7 +304,7 @@ Modify the content of this file, for example turn on the debug flag:
 ```
 Then patch the existing `ConfigMap`: 
 
-```
+```shell
 kubectl create cm flag-configuration --from-file=flag-config.json=flag-config.json --dry-run=client -o yaml | kubectl patch cm flag-configuration --type merge --patch-file /dev/stdin
 ```
 
@@ -336,7 +336,7 @@ In this example, we haven't used more advanved features to evaluate feature flag
 
 If you want to get rid of the KinD Cluster created for this tutorial, you can run:
 
-```
+```shell
 kind delete clusters dev
 ```
 

--- a/chapter-8/README.md
+++ b/chapter-8/README.md
@@ -10,15 +10,15 @@ In these tutorials you will install Knative Serving and Argo Rollouts on a Kuber
 
 If you want to get rid of the KinD Cluster created for this tutorial, you can run:
 
-```
+```shell
 kind delete clusters dev
 ```
 
 ## Next Steps
 
-- Check the [Knative Functions](https://knative.dev/docs/functions/) project if you are intereted in building a Function-as-a-Service platform, as this initiative is working on tooling to make Function developers life easier.
+- Check the [Knative Functions](https://knative.dev/docs/functions/) project if you are interested in building a Function-as-a-Service platform, as this initiative is working on tooling to make Function developers life easier.
 
-- After tryingout Argo Rollouts, the next step is to create an example end-to-end showing the flow of Argo CD to Argo Rollouts. This requires to create a repository that contains your Rollouts definitions. Check the [FAQ section on the Argo Projects](https://argo-rollouts.readthedocs.io/en/latest/FAQ/) for more details about their integration.
+- After trying out Argo Rollouts, the next step is to create an example end-to-end showing the flow of Argo CD to Argo Rollouts. This requires to create a repository that contains your Rollouts definitions. Check the [FAQ section on the Argo Projects](https://argo-rollouts.readthedocs.io/en/latest/FAQ/) for more details about their integration.
 
 - Experiment with more complex examples using `AnalysisTemplates` and `AnalysisRuns` as this feature helps teams to deploy new versions with more confident. 
 

--- a/chapter-9/README.md
+++ b/chapter-9/README.md
@@ -16,7 +16,7 @@ Platform teams should evaluate tools like the ones presented here, not only to c
 
 If you want to get rid of the KinD Cluster created for this tutorial, you can run:
 
-```
+```shell
 kind delete clusters dev
 ```
 

--- a/chapter-9/dora-cloudevents/README.md
+++ b/chapter-9/dora-cloudevents/README.md
@@ -18,18 +18,18 @@ Then we will install Knative Eventing, this is optional, as we will use Knative 
 
 
 1. Install [Knative Eventing](https://knative.dev/docs/install/yaml-install/eventing/install-eventing-with-yaml/)
-```
+```shell
 kubectl apply -f https://github.com/knative/eventing/releases/download/knative-v1.11.0/eventing-crds.yaml
 kubectl apply -f https://github.com/knative/eventing/releases/download/knative-v1.11.0/eventing-core.yaml
 ```
 
 1. Create your "dora-cloudevents" namespace: 
-```
+```shell
 kubectl create ns dora-cloudevents
 ```
 
 1. Install PostgreSQL and Create Tables
-```
+```shell
 kubectl apply -f resources/dora-sql-init.yaml
 helm install postgresql oci://registry-1.docker.io/bitnamicharts/postgresql --version 12.5.7 --namespace dora-cloudevents --set "image.debug=true" --set "primary.initdb.user=postgres" --set "primary.initdb.password=postgres" --set "primary.initdb.scriptsConfigMap=dora-init-sql" --set "global.postgresql.auth.postgresPassword=postgres" --set "primary.persistence.size=1Gi"
 ```
@@ -37,12 +37,12 @@ helm install postgresql oci://registry-1.docker.io/bitnamicharts/postgresql --ve
 
 1. Install Sockeye, a simple CloudEvents monitor, it requires Knative Serving to be installed: 
 
-```
+```shell
 kubectl apply -f https://github.com/n3wscott/sockeye/releases/download/v0.7.0/release.yaml
 ```
 
 1. Install the [Kubernetes API Server CloudEvent Event Source](https://knative.dev/docs/eventing/sources/apiserversource/getting-started/#create-an-apiserversource-object): 
-```
+```shell
 kubectl apply -f api-serversource-deployments.yaml
 ```
 
@@ -72,7 +72,7 @@ This demo deploys the following components to transform CloudEvents into CDEvent
 
 First deploy the components and transformation functions by running: 
 
-```
+```shell
 kubectl apply -f resources/components.yaml
 ```
 
@@ -81,7 +81,7 @@ Open Sockeye to monitor CloudEvents by pointing your browser to [http://sockeye.
 
 Then, create a new Deployment in the `default` namespace to test that your configuration is working.
 
-```
+```shell
 kubectl apply -f test/example-deployment.yaml
 ```
 
@@ -91,12 +91,12 @@ At this point you should see tons of events in Sockeye:
 
 If the Deployment Frequency functions (transformation and calculation) are installed you should be able to query the deployment frequency endpoint and see the metric. Notice that this can take up to a couple of minutes, as Cron jobs are being used to aggregate the data periodically:  
 
-```
+```shell
 curl http://dora-frequency-endpoint.dora-cloudevents.127.0.0.1.sslip.io/deploy-frequency/day | jq
 ```
 And see something like this, depending on which deployments you created (I've created two deployments: `nginx-deployment` and `nginx-deployment-3`): 
 
-```
+```shell
 [
   {
     "DeployName": "nginx-deployment",
@@ -117,19 +117,19 @@ Try modifying the deployments or creating new ones, the components are configure
 Notice that all the components were installed in the `dora-cloudevents` namespace. You check the pods and the URL for the Knative Services by running the following commands: 
 
 Check the URL for the Knative Services in the `dora-cloudevents` namespace:
-```
+```shell
 kubectl get ksvc -n dora-cloudevents
 ```
 
 Check which pods are running, I find this interesting as because we are using Knative Serving, all transformation functions that are not being used doesn't need to be running all the time: 
 
-```
+```shell
 kubectl get pods -n dora-cloudevents
 ```
 
 Finally you can check all the CronJob executions that aggregates data by running: 
 
-```
+```shell
 kubectl get cronjobs -n dora-cloudevents
 ```
 
@@ -138,7 +138,7 @@ kubectl get cronjobs -n dora-cloudevents
 
 Deploy the `dora-cloudevents` components using `ko` for development:
 
-```
+```shell
 ko apply -f config/
 ```
 
@@ -169,7 +169,7 @@ Calculate buckets: Daily, Weekly, Monthly, Yearly.
 
 This counts the number of deployments per day: 
 
-```
+```sql
 SELECT
 distinct deploy_name AS NAME,
 DATE_TRUNC('day', time_created) AS day,

--- a/chapter-9/keptn/README.md
+++ b/chapter-9/keptn/README.md
@@ -11,7 +11,7 @@ Then we can install the Keptn Lifecycle Toolkit (KLT). This can be usually done 
 
 Run: 
 
-```
+```shell
 make install
 ```
 
@@ -19,7 +19,7 @@ make install
 
 Finally, we need to let KLT know which namespace we want to monitor, and for that we need to annotate the namespaces:
 
-```
+```shell
 kubectl annotate ns default keptn.sh/lifecycle-toolkit="enabled"
 ```
 
@@ -28,7 +28,7 @@ kubectl annotate ns default keptn.sh/lifecycle-toolkit="enabled"
 Keptn uses standard Kubernetes annotation to recognized and monitor our workloads. 
 The Kubernetes Deployments used by the Conference Application are annotated with the following annotations, for example the Agenda Service: 
 
-```
+```shell
         app.kubernetes.io/name: agenda-service
         app.kubernetes.io/part-of: agenda-service
         app.kubernetes.io/version: {{ .Values.services.tag  }}
@@ -38,7 +38,7 @@ These annotations allow tools to understand a bit more about our workloads, for 
 
 On this example we will be also using a KeptnTask, that enable us to perform pre and post deployment tasks. You can deploy the following extremely simple example `KeptnTaskDefinition`:
 
-```
+```yaml
 apiVersion: lifecycle.keptn.sh/v1alpha3
 kind: KeptnTaskDefinition
 metadata:
@@ -57,19 +57,19 @@ As you can see this task is only printing the context from its execution, but he
 
 By running: 
 
-```
+```shell
 kubectl apply -f keptntask.yaml
 ```
 
 KeptnTaskDefinitions allow Platform Teams to create reusable tasks that can be hooked into Pre/Post deployment hooks of our applications. By adding the following annotation to our workloads (deployments in this case), Keptn will execute the `stdout-notification` automatically, in this case after performing the deployment (and after any update): 
 
-```
+```shell
   keptn.sh/post-deployment-tasks: stdout-notification
 ``` 
 
 Let's deploy the Conference application, and lets open Jaeger and Grafana Dashboards. In separate tabs run: 
 
-```
+```shell
 make port-forward-jaeger
 ```
 
@@ -80,7 +80,7 @@ You can point your browser to [http://localhost:16686/](http://localhost:16686/)
 
 and then in a separate terminal: 
 
-```
+```shell
 make port-forward-grafana
 ```
 
@@ -91,7 +91,7 @@ You can point your browser to [http://localhost:3000/](http://localhost:3000/). 
 
 Let's now deploy the Conference Application as we did in Chapter 2: 
 
-```
+```shell
 helm install conference oci://registry-1.docker.io/salaboy/conference-app --version v1.0.0
 ```
 
@@ -101,7 +101,7 @@ In Grafana go to `Dashboards` -> `Keptn Applications`.  You will see a drop down
 
 For example, edit the notifications-service deployment and update the `app.kubernetes.io/version` annotation to have the value `v1.1.0` and update the tag used for the container image to be `v1.1.0`
 
-```
+```shell
 kubectl edit deploy conference-notifications-service-deployment
 ```
 
@@ -116,7 +116,7 @@ If you look at the traces in Jaeger, you will see that the `lifecycle-operator` 
 
 These tasks are executed as Kubernetes Jobs in the same namespace where the workloads are running. You can take a look at the logs from this tasks by tailing the jobs pod's logs. 
 
-```
+```shell
 kubectl get jobs
 NAME                                   COMPLETIONS   DURATION   AGE
 post-stdout-notification-25899-78387   1/1           3s         66m
@@ -129,7 +129,7 @@ post-stdout-notification-93609-30317   1/1           3s         23m
 
 The Job with id `post-stdout-notification-93609-30317` was executed after I've performed the update on the Notification Service deployment. 
 
-```
+```shell
 > kubectl logs -f post-stdout-notification-93609-30317-vvwp4
 Keptn Task Executed with context: 
 

--- a/conference-admin/helm/conference-admin/README.md
+++ b/conference-admin/helm/conference-admin/README.md
@@ -8,7 +8,7 @@ This chart doesn't depend on anything to be installed in the target Kubernetes C
 ## Installation 
 
 
-```
+```shell
 helm install conference oci://registry-1.docker.io/salaboy/conference-app --version v1.0.0 -n chapter02
 ```
 
@@ -20,7 +20,7 @@ Chart parameters:
 
 ## Packaging and distributing the chart
 
-```
+```shell
 helm dependency build
 helm package .
 helm push conference-app-v1.0.0.tgz oci://registry-1.docker.io/salaboy/
@@ -28,7 +28,7 @@ helm push conference-app-v1.0.0.tgz oci://registry-1.docker.io/salaboy/
 
 ## Interacting with the application
 
-```
+```shell
 kubectl port-forward svc/frontend -n chapter02 8080:80
 ```
 

--- a/conference-application/c4p-service/README.md
+++ b/conference-application/c4p-service/README.md
@@ -15,11 +15,11 @@
 
 ## Build & Run from source
 
-```
+```shell
 docker-compose up 
 ```
 
-```
+```shell
 go run c4p-service.go
 ```
 ## Create Container

--- a/conference-application/from-source/README.md
+++ b/conference-application/from-source/README.md
@@ -6,13 +6,13 @@ For Kubernetes 1.23 you need Knative 1.8 for Kubernetes 1.24 you need Knative 1.
 
 If you have [Knative Serving installed](https://knative.dev/docs/install/yaml-install/serving/install-serving-with-yaml/#verify-the-installation) in your cluster you can leverage the `config-knative` directory when running
 
-```
+```shell
 ko apply -f config-knative/
 ```
 
 You can install Redis using the Bitnami Helm Chart: 
 
-```
+```shell
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo update
 helm install redis bitnami/redis --set image.tag=6.2 --set architecture=standalone
@@ -20,22 +20,22 @@ helm install redis bitnami/redis --set image.tag=6.2 --set architecture=standalo
 
 
 Before installing PostgreSQL, we need to create a configMap with the tables that we want to create: 
-```
+```shell
 kubectl apply -f c4p-service/init-sql-configmap.yaml
 ```
 
 Same with PostgreSQL: 
-```
+```shell
 helm install postgres oci://registry-1.docker.io/bitnamicharts/postgresql --set image.debug=true --set global.postgresql.auth.postgresPassword=postgres --set primary.initdb.user=postgres --set primary.initdb.password=postgres --set primary.initdb.scriptsConfigMap=init-sql
 ```
 
 and Kafka:
 
-```
+```shell
 helm install kafka oci://registry-1.docker.io/bitnamicharts/kafka
 ```
 
 Optional Ingress Controller: 
-```
+```shell
 helm install ingress-controller oci://registry-1.docker.io/bitnamicharts/nginx-ingress-controller
 ```

--- a/conference-application/frontend-next/README.md
+++ b/conference-application/frontend-next/README.md
@@ -37,13 +37,13 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/deploym
 ## To generate a static distribution
 
 First make sure that  `next.config.js` has: 
-```
+```js
 output: 'export', 
 ```
 
 Run
 
-```
+```shell
 npm run build
 ```
 

--- a/conference-application/helm/conference-app/README.md
+++ b/conference-application/helm/conference-app/README.md
@@ -8,7 +8,7 @@ This chart doesn't depend on anything to be installed in the target Kubernetes C
 ## Installation 
 
 
-```
+```shell
 helm install conference oci://registry-1.docker.io/salaboy/conference-app --version v1.0.0 -n chapter02
 ```
 
@@ -20,7 +20,7 @@ Chart parameters:
 
 ## Packaging and distributing the chart
 
-```
+```shell
 helm dependency build
 helm package .
 helm push conference-app-v1.0.0.tgz oci://registry-1.docker.io/salaboy/
@@ -28,7 +28,7 @@ helm push conference-app-v1.0.0.tgz oci://registry-1.docker.io/salaboy/
 
 ## Interacting with the application
 
-```
+```shell
 kubectl port-forward svc/frontend -n chapter02 8080:80
 ```
 


### PR DESCRIPTION
Changes 
Related to #32 
🧹  Readme files (`en` only) : All code snippets now have the proper types
🧹 Chapter02: moving an osx error troubleshooting to an admonition block

/kind cleanup

Release Note

- Styling in all code snippets on the (english) readme files
- Chapter02: Improved readability,  optional block (only read in case of errors) is now a note.