### PR TITLE
[Translations]Add Japanese translation link to all README versions

### DIFF
--- a/README-es.md
+++ b/README-es.md
@@ -4,7 +4,7 @@ Este repositorio contiene todo el código fuente, los tutoriales y los ejemplos 
 
 ## Tutoriales de Kubernetes
 
-Disponible en: [Inglés](README.md) | [Chino](README-zh.md) | [Portugués](README-pt.md)
+Disponible en: [Inglés](README.md) | [Chino](README-zh.md) | [Portugués](README-pt.md) | [日本語 (Japanese)](README-ja.md)
 
 Nota: Esta diversidad lingüística es posible gracias a los contribuyentes de una fantástica comunidad de cloud-native. ¡Muchas gracias! 🚀
 

--- a/README-pt.md
+++ b/README-pt.md
@@ -6,7 +6,7 @@ Este repositório contém todo o código-fonte, tutoriais e exemplos do livro [E
 
 ## Tutoriais K8s
 
-_Disponível em_: [English](README.md) | [中文 (Chinese)](README.zh.md) | [Português(Portuguese)](README-pt.md)
+_Disponível em_: [English](README.md) | [中文 (Chinese)](README.zh.md) | [Português(Portuguese)](README-pt.md) | [日本語 (Japanese)](README-ja.md)
 > **Nota:** Essa diversidade de idiomas é trazida até você por [contribuidores](https://github.com/salaboy/platforms-on-k8s/graphs/contributors) de uma fantástica comunidade cloud native. Muito obrigado! 🚀
 
 Cada capítulo do livro refere-se a um tutorial passo a passo que você pode executar para se familiarizar com alguns projetos open-source.

--- a/chapter-1/README-es.md
+++ b/chapter-1/README-es.md
@@ -1,7 +1,7 @@
 # Capitulo 1 :: (El surgimiento de) Plataformas basadas en Kubernetes
 
 —
-_🌍 Disponible en_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [Português (Portuguese)](README-pt.md) | [Español](README-es.md)
+_🌍 Disponible en_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [Português (Portuguese)](README-pt.md) | [Español](README-es.md) | [日本語 (Japanese)](README-ja.md)
 > **Nota:** Presentado por la fantástica comunidad de [ 🌟 contribuidores](https://github.com/salaboy/platforms-on-k8s/graphs/contributors) cloud-native!
 
 —

--- a/chapter-1/README-pt.md
+++ b/chapter-1/README-pt.md
@@ -1,7 +1,7 @@
 # Capítulo 1 :: (A ascensão das) Plataformas Baseadas em Kubernetes
 
 ---
-_🌍 Disponível em_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [Português (Portuguese)](README-pt.md)
+_🌍 Disponível em_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [Português (Portuguese)](README-pt.md) | [日本語 (Japanese)](README-ja.md)
 
 > **Nota:** Trago a você pela fantástica comunidade cloud-native e seus [ 🌟 contribuidores](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
 ---

--- a/chapter-1/README.md
+++ b/chapter-1/README.md
@@ -1,7 +1,7 @@
 # Chapter 1 :: (The rise of) Platforms on Top of Kubernetes
 
 ---
-_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [Português (Portuguese)](README-pt.md) | [Español](README-es.md)
+_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [Português (Portuguese)](README-pt.md) | [Español](README-es.md) | [日本語 (Japanese)](README-ja.md)
 > **Note:** Brought to you by the fantastic cloud-native community's [ 🌟 contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
 
 ---

--- a/chapter-2/README-es.md
+++ b/chapter-2/README-es.md
@@ -1,7 +1,7 @@
 # Capitulo 2 :: Desafios de una Aplicación Cloud-Native
 
 —
-_🌍 Disponible en_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [Português (Portuguese)](README-pt.md) | [Español](README-es.md)
+_🌍 Disponible en_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [Português (Portuguese)](README-pt.md) | [Español](README-es.md) | [日本語 (Japanese)](README-ja.md)
 > **Nota:** Presentado por la fantástica comunidad de [ 🌟 contribuidores](https://github.com/salaboy/platforms-on-k8s/graphs/contributors) cloud-native!
 
 En este breve tutorial, instalaremos la `Aplicación para Conferencia` usando Helm en un Clúster Kubernetes local de KinD. 

--- a/chapter-2/README-pt.md
+++ b/chapter-2/README-pt.md
@@ -1,7 +1,7 @@
 # Capítulo 2 :: Desafios da Aplicação Cloud Native
 
 ---
-_🌍 Disponível em_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [Português (Portuguese)](README-pt.md)
+_🌍 Disponível em_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [Português (Portuguese)](README-pt.md) | [日本語 (Japanese)](README-ja.md)
 
 > **Nota:** Trago a você pela fantástica comunidade cloud-native e seus [ 🌟 contribuidores](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
 

--- a/chapter-2/README.md
+++ b/chapter-2/README.md
@@ -1,7 +1,7 @@
 # Chapter 2 :: Cloud-Native Application Challenges
 
 ---
-_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [Português (Portuguese)](README-pt.md) 
+_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [Português (Portuguese)](README-pt.md)  | [日本語 (Japanese)](README-ja.md)
 
 > **Note:** Brought to you by the fantastic cloud-native community's [ 🌟 contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
 

--- a/chapter-3/README.md
+++ b/chapter-3/README.md
@@ -1,7 +1,7 @@
 # Service Pipelines
 
 ---
-_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md)
+_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [日本語 (Japanese)](README-ja.md)
 > **Note:** Brought to you by the fantastic cloud-native community's [ 🌟 contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
 
 ---

--- a/chapter-4/README.md
+++ b/chapter-4/README.md
@@ -1,7 +1,7 @@
 # Environment Pipelines
 
 ---
-_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md)
+_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [日本語 (Japanese)](README-ja.md)
 > **Note:** Brought to you by the fantastic cloud-native community's [ 🌟 contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
 
 ---

--- a/chapter-5/README.md
+++ b/chapter-5/README.md
@@ -1,7 +1,7 @@
 # Multi-Cloud (App) Infrastructure
 
 ---
-_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md)
+_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [日本語 (Japanese)](README-ja.md)
 
 > **Note:** Brought to you by the fantastic cloud-native community's [ 🌟 contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
 

--- a/chapter-5/aws/README.md
+++ b/chapter-5/aws/README.md
@@ -1,7 +1,7 @@
 # AWS Cloud Provider
 
 ---
-_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md)
+_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [日本語 (Japanese)](README-ja.md)
 
 > **Note:** Brought to you by the fantastic cloud-native community's [ 🌟 contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
 

--- a/chapter-6/README.md
+++ b/chapter-6/README.md
@@ -1,7 +1,7 @@
 # Chapter 6 :: Let's build a Platform on top of Kubernetes
 
 ---
-_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md)
+_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [日本語 (Japanese)](README-ja.md)
 
 > **Note:** Brought to you by the fantastic cloud-native community's [ 🌟 contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
 

--- a/chapter-7/README.md
+++ b/chapter-7/README.md
@@ -1,7 +1,7 @@
 # Chapter 7 :: Shared Applications Concerns
 
 ---
-_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md)
+_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [日本語 (Japanese)](README-ja.md)
 
 > **Note:** Brought to you by the fantastic cloud-native community's [ 🌟 contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
 

--- a/chapter-8/README.md
+++ b/chapter-8/README.md
@@ -1,7 +1,7 @@
 # Chapter 8 :: Enabling Teams to Experiment
 
 ---
-_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md)
+_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [日本語 (Japanese)](README-ja.md)
 
 > **Note:** Brought to you by the fantastic cloud-native community's [ 🌟 contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
 

--- a/chapter-8/argo-rollouts/README.md
+++ b/chapter-8/argo-rollouts/README.md
@@ -1,7 +1,7 @@
 # Release Strategies with Argo Rollouts
 
 ---
-_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md)
+_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [日本語 (Japanese)](README-ja.md)
 
 > **Note:** Brought to you by the fantastic cloud-native community's [ 🌟 contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
 

--- a/chapter-8/knative/README.md
+++ b/chapter-8/knative/README.md
@@ -1,7 +1,7 @@
 # Release Strategies with Knative Serving
 
 ---
-_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md)
+_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [日本語 (Japanese)](README-ja.md)
 
 > **Note:** Brought to you by the fantastic cloud-native community's [ 🌟 contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
 

--- a/chapter-9/README.md
+++ b/chapter-9/README.md
@@ -1,7 +1,7 @@
 # Chapter 9 :: Measuring your Platforms
 
 ---
-_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md)
+_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [日本語 (Japanese)](README-ja.md)
 
 > **Note:** Brought to you by the fantastic cloud-native community's [ 🌟 contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
 

--- a/chapter-9/dora-cloudevents/README.md
+++ b/chapter-9/dora-cloudevents/README.md
@@ -1,7 +1,7 @@
 # DORA Metrics + CloudEvents & CDEvents for Kubernetes
 
 ---
-_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md)
+_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [日本語 (Japanese)](README-ja.md)
 
 > **Note:** Brought to you by the fantastic cloud-native community's [ 🌟 contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
 

--- a/chapter-9/keptn/README.md
+++ b/chapter-9/keptn/README.md
@@ -1,7 +1,7 @@
 # Keptn Lifecycle Toolkit, out of the box Deployment Frequency
 
 ---
-_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md)
+_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [日本語 (Japanese)](README-ja.md)
 
 > **Note:** Brought to you by the fantastic cloud-native community's [ 🌟 contributors](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)!
 


### PR DESCRIPTION
## 📝 Description
Related to [#61](https://github.com/salaboy/platforms-on-k8s/issues/61)
/kind documentation

Dear @salaboy and the esteemed platforms-on-k8s team,

I hope this message finds you well. As we continue to enhance the accessibility of the "Platforms on Top of Kubernetes" book, I'm pleased to submit this PR to add the Japanese translation link to the other language versions of the README. 🌐

This small but significant change will help increase visibility of the Japanese translation and improve navigation for our multilingual readers. 🧭

## 🔄 Changes
- ➕ Added the Japanese translation link to all README files using the following shell script:
  ```sh
  find . -name 'README.md' -type f -exec sed -i '' 's/\(_🌍 Available in_: \[English\](README\.md).*\)/\1 | [日本語 (Japanese)](README-ja.md)/' {} +
  ```
- 🔍 Ensured consistent formatting with existing language links
- 🌐 Verified that the link correctly points to the Japanese README (README-ja.md)

## 📌 Notes
- 🎯 This update aims to create a more interconnected experience for readers across all language versions
- 🌏 By adding this link, we're further supporting the global Kubernetes and cloud-native community
- 💬 I welcome any feedback or suggestions for improvement in how we present language options
- 🛠️ The use of the shell script ensured consistency across all README files and minimized the chance of manual errors

Thank you for your continued support and dedication to making this valuable resource accessible to a global audience. Your efforts in maintaining and improving this project are truly appreciated. ✨

I look forward to your review and am happy to make any necessary adjustments. 🙏