### PR TITLE
[Translation] Add Japanese version of main

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1,0 +1,32 @@
+# Kubernetes上のプラットフォームエンジニアリング :: 書籍コード / チュートリアル / 例
+
+このリポジトリには、[Platform Engineering on Kubernetes](https://www.salaboy.com/book/)書籍のすべてのソースコード、チュートリアル、例が含まれています。
+
+---
+
+## Kubernetesチュートリアル
+
+_利用可能な言語_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [Português (Portuguese)](README-pt.md) | [Español](README-es.md) | [日本語 (Japanese)](README-ja.md)
+> **注意:** このような言語の多様性は、素晴らしいクラウドネイティブコミュニティの[貢献者](https://github.com/salaboy/platforms-on-k8s/graphs/contributors)によってもたらされました。大変感謝します！🚀
+
+書籍の各章では、いくつかのオープンソースプロジェクトを実際に体験できるステップバイステップのチュートリアルを参照しています。
+
+- [第1章: Kubernetes上のプラットフォーム（の台頭）](chapter-1/README-ja.md)
+- [第2章: クラウドネイティブアプリケーションの課題](chapter-2/README-ja.md)
+- [第3章: サービスパイプライン：クラウドネイティブアプリケーションの構築](chapter-3/README-ja.md)
+- [第4章: 環境パイプライン：クラウドネイティブアプリケーションのデプロイ](chapter-4/README-ja.md)
+- [第5章: マルチクラウド（アプリ）インフラストラクチャ](chapter-5/README-ja.md)
+- [第6章: Kubernetes上にプラットフォームを構築しよう](chapter-6/README-ja.md)
+- [第7章: プラットフォーム機能 I：共有アプリケーションの課題](chapter-7/README-ja.md)
+- [第8章: プラットフォーム機能 II：チームに実験の機会を与える](chapter-8/README-ja.md)
+- [第9章: プラットフォームを測定する](chapter-9/README-ja.md)
+
+次に、チュートリアルで使用され、書籍で言及されているアプリケションに関する情報を見つけることができます。
+
+## コード
+
+Conference Application（ウォーキングスケルトン）のコードと、Helmチャートや設定ファイルなどの関連アーティファクトは、[conference-application](conference-application/README-ja.md)ディレクトリ内にあります。これらの例はすべてソースからビルドでき、これらのアプリケーションを探索し変更することをお勧めします。
+
+## コメント / 提案 / 質問
+
+コメント、提案、質問がある場合は、[issueを開く](https://github.com/salaboy/platforms-on-k8s/issues/new)か、私のブログ[https://www.salaboy.com](https://www.salaboy.com)にコメントを残すか、[Twitter @Salaboy](https://twitter.com/salaboy)で連絡してください。


### PR DESCRIPTION
## 📝 Description
Continues work on [#61](https://github.com/salaboy/platforms-on-k8s/issues/61)
/kind documentation

Dear @salaboy and the exceptional platforms-on-k8s team,

## 🔄 Changes
- ➕ Integrated index content into README-ja.md
- 🔍 Ensured consistency in formatting and style with both the original English version and all previous translations
- 🔄 Updated the table of contents in README-ja.md to include index

## 📌 Notes
- 🎯 As with all previous chapters, I've maintained a balance between accuracy and natural Japanese expression
- 🌏 This translation continues to expand the resources available to the Japanese-speaking Kubernetes and cloud-native community
- 💬 I warmly welcome any feedback or suggestions for improvement, which will be crucial as we approach the project's completion
- 🚀 I will be working on the remaining tasks, including [brief description of additional tasks], and will keep you updated on the progress