### PR TITLE
docs: chapter 7 - spanish translation

### DIFF
--- a/chapter-7/README-es.md
+++ b/chapter-7/README-es.md
@@ -8,11 +8,13 @@ _🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [
 
 ---
 
-In this step-by-step tutorial, we will look into using [Dapr](https://dapr.io) to provide Application-level APIs to solve everyday challenges that most Distributed Applications will face. 
+En este tutorial paso a paso, veremos como usar [Dapr](https://dapr.io) para proporcionar APIs a nivel de Aplicación para resolver los problemas que la mayoría de las Aplicaciones Distribuidas tienen que resolver.
 
-Then we will look at [OpenFeature](https://openfeature.dev), a project that aims to standardize Feature Flags so development teams can keep releasing new features and stakeholders can decide when to enable/disable these features for their customers. 
+Luego miraremos [OpenFeature](https://openfeature.dev), un proyecto que está hecho para estandarizar las banderas de características y así los equipos de Desarrollo puedan seguir lanzando nuevas funcionalidades y los stakeholders puedan decidir cuándo habilitar/desactivar estas características para sus clientes.
 
-Because both projects are focused on providing developers with new APIs and tools to use inside their service's code, we will deploy a new version of the application (`v2.0.0`). You can find all the changes required for this new version in the `v2.0.0` of this repository. [You can also compare the differences between the branches here](https://github.com/salaboy/platforms-on-k8s/compare/v2.0.0).
+Debido a que ambos proyectos están enfocados en proveer a los desarrolladores con nuevas API y herramientas que utilizar dentro del código de sus servicios, desplegaremos una nueva versión de la aplicación (`v2.0.0).
+encontrarás todos los cambios requeridos para esta nueva versión en la rama `v2.0.0` de este repositorio.
+Puedes comparar las diferencias entre las ramas aquí](https://github.com/salaboy/platforms-on-k8s/compare/v2.0.0).
 
 
 # Installation

--- a/chapter-7/README-es.md
+++ b/chapter-7/README-es.md
@@ -1,21 +1,20 @@
-# Capítulo 7 :: Shared Applications Concerns
+# Capítulo 7:: Preocupaciones Compartidas de Aplicaciones
 
 ---
-_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [日本語 (Japanese)](README-ja.md) | [Español](README-es.md)
+_🌍 Disponible en: [English](README.md) | [中文 (Chinese)](README-zh.md) | [日本語 (Japanese)](README-ja.md) | [Español](README-es.md)
 
 > **Nota:** Presentado por la fantástica comunidad
 > de [ 🌟 contribuidores](https://github.com/salaboy/platforms-on-k8s/graphs/contributors) cloud-native!
 
 ---
 
-En este tutorial paso a paso, veremos como usar [Dapr](https://dapr.io) para proporcionar APIs a nivel de Aplicación para resolver los problemas que la mayoría de las Aplicaciones Distribuidas tienen que resolver.
+En este tutorial paso a paso, veremos como usar [Dapr](https://dapr.io) para proporcionar API a nivel de Aplicación para resolver los problemas que la mayoría de las Aplicaciones Distribuidas tienen que resolver.
 
-Luego miraremos [OpenFeature](https://openfeature.dev), un proyecto que está hecho para estandarizar las banderas de características y así los equipos de Desarrollo puedan seguir lanzando nuevas funcionalidades y los stakeholders puedan decidir cuándo habilitar/desactivar estas características para sus clientes.
+Luego miraremos [OpenFeature](https://openfeature.dev), un proyecto que está hecho para estandarizar las _feature flags_ y así los equipos de Desarrollo puedan seguir lanzando nuevas funcionalidades y los stakeholders puedan decidir cuándo habilitar/desactivar estas características para sus clientes.
 
-Debido a que ambos proyectos están enfocados en proveer a los desarrolladores con nuevas API y herramientas que utilizar dentro del código de sus servicios, desplegaremos una nueva versión de la aplicación (`v2.0.0).
-encontrarás todos los cambios requeridos para esta nueva versión en la rama `v2.0.0` de este repositorio.
-Puedes comparar las diferencias entre las ramas aquí](https://github.com/salaboy/platforms-on-k8s/compare/v2.0.0).
-
+Debido a que ambos proyectos están enfocados en proveer a los desarrolladores con nuevas API y herramientas que utilizar dentro del código de sus servicios, desplegaremos una nueva versión de la aplicación (`v2.0.0`).
+Encontrarás todos los cambios requeridos para esta nueva versión en la rama `v2.0.0` de este repositorio.
+[Puedes comparar las diferencias entre las ramas aquí](https://github.com/salaboy/platforms-on-k8s/compare/v2.0.0).
 
 # Instalación
 
@@ -46,7 +45,7 @@ helm install conference oci://docker.io/salaboy/conference-app --version v2.0.0
 Esta versión del chart de Helm instala la misma infraestructura de la aplicación que la versión
 `v1.0.0` (PostgreSQL, Redis, y Kafka).
 Los servicios que interactúan con Redis y Kafka ahora usan las API de Dapr.
-Esta versión de la aplicación también añade banderas de características OpenFeature utilizando `flagd`.
+Esta versión de la aplicación también añade feature flags OpenFeature utilizando `flagd`.
 
 # API a nivel de aplicación con Dapr
 
@@ -179,19 +178,19 @@ Events:       <none>
 ```
 
 Como puedes ver,
-esta suscripción reenvía los eventos a la ruta `/api/new-events/` para que las aplicaciones Daps listadas
-en la sección `Scopes`, solo la aplicación `frontend`.
+esta suscripción reenvía los eventos a la ruta `/api/new-events/` para que las aplicaciones Dapr listadas
+en la sección `Scopes`.
 Solo la aplicación Frontend necesita exponer el endpoint para recibir eventos,
 en este caso el sidecar de Dapr (`daprd`)
 espera los mensajes entrantes en el componente PubSub llamado `conference-conference-pubsub` y reenvía todos los mensajes al endpoint de la Aplicación.
 
-Esta versión de la aplicación eliminar dependencias de la aplicación tales como el cliente de Kafka de todos los servicios y el cliente de Redis del servicio de Agenda.
+Esta versión de la aplicación elimina dependencias de la aplicación tales como el cliente de Kafka de todos los servicios y el cliente de Redis del servicio de Agenda.
 
 
 ![services without deps](imgs/conference-app-dapr-no-deps.png)
 
-Ademas de eliminar las dependencias y hacer los contenedores más pequeños,
-al consumir la API de los componentes Dapr, permitimos que el equipo de plataforma defina cómo se configurar esos componentes y sobre qué infraestructura.
+Además de eliminar las dependencias y hacer los contenedores más pequeños,
+al consumir la API de los componentes Dapr, permitimos que el equipo de plataformas defina cómo se configuran esos componentes y sobre qué infraestructura.
 Configurar la misma aplicación para usar servicios administrados de Google Cloud Platform como [Google PubSub](https://cloud.google.com/pubsub) o la [MemoryStore databases](https://cloud.google.com/memorystore) no requiere cambios en el código de la aplicación o agregar nuevas dependencias, solo se necesitan nuevas configuraciones de componentes de Dapr.
 
 ![in gcp](imgs/conference-app-dapr-and-gcp.png)
@@ -199,21 +198,17 @@ Configurar la misma aplicación para usar servicios administrados de Google Clou
 Finalmente, ya que todo se trata de permitir que los desarrolladores utilicen las API a nivel de aplicación, miremos cómo se ve desde la perspectiva del servicio.
 Como los servicios están escritos en Go, he decidido añadir la SDK de Dapr para Go (que es opcional).
 
-Cuando el servicio de Agenda quiere almacenar o leer datos del componente Statestore, puede utilizar el cliente Dapr para realizar estar operaciones, por ejemplo 
-
-Finally, because this is all about enabling developers with Application Level APIs, let's look at how this looks from the application's service perspective. Because the services are written in Go, I've decided to add the Dapr Go SDK (which is optional). 
-
-When the Agenda Service wants to store or read data from the Dapr Statestore component, it can use the Dapr Client to perform these operations, for example [reading values from the Statestore looks like this](https://github.com/salaboy/platforms-on-k8s/blob/v2.0.0/conference-application/agenda-service/agenda-service.go#L136C2-L136C116): 
+Cuando el servicio de Agenda quiere almacenar o leer datos del componente Statestore, puede utilizar el cliente Dapr para realizar estar operaciones, por ejemplo:
 
 ```golang
 agendaItemsStateItem, err := s.APIClient.GetState(ctx, STATESTORE_NAME, fmt.Sprintf("%s-%s", TENANT_ID, KEY), nil)
 ```
 
-The `APIClient` reference is just a [Dapr Client instance, which was initialized here](https://github.com/salaboy/platforms-on-k8s/blob/v2.0.0/conference-application/agenda-service/agenda-service.go#L397)
+La referencia `APIClient` es una [instancia del cliente Dapr, que se ha iniciado aquí](https://github.com/salaboy/platforms-on-k8s/blob/v2.0.0/conference-application/agenda-service/agenda-service.go#L397)
 
-All the application needs to know is the Statestore name (`STATESTORE_NAME`) and the key (`KEY`) to locate the data that wants to be retrieved.
+Todo lo que la aplicación necesita saber es el nombre del componente Statestore (`STATESTORE_NAME`) y la clave (`KEY`) para localizar el dato que quiere recuperar.
 
-When the application wants to [store state into the Statestore it looks like this](https://github.com/salaboy/platforms-on-k8s/blob/v2.0.0/conference-application/agenda-service/agenda-service.go#L197C2-L199C3):
+Cuando la aplicación necesita [almacenar un estado en la Statestore, se utiliza asi](https://github.com/salaboy/platforms-on-k8s/blob/v2.0.0/conference-application/agenda-service/agenda-service.go#L197C2-L199C3):
 
 ```golang
 if err := s.APIClient.SaveState(ctx, STATESTORE_NAME, fmt.Sprintf("%s-%s", TENANT_ID, KEY), jsonData, nil); err != nil {
@@ -221,7 +216,8 @@ if err := s.APIClient.SaveState(ctx, STATESTORE_NAME, fmt.Sprintf("%s-%s", TENAN
 }
 ```  
 
-Finally, if the application code wants to [publish a new event to the PubSub component](https://github.com/salaboy/platforms-on-k8s/blob/v2.0.0/conference-application/agenda-service/agenda-service.go#L225), it will look like this: 
+Finalmente,
+si la aplicación necesita [publicar un nuevo evento en el componente PubSub](https://github.com/salaboy/platforms-on-k8s/blob/v2.0.0/conference-application/agenda-service/agenda-service.go#L225), se utiliza asi:
 
 ```golang
 if err := s.APIClient.PublishEvent(ctx, PUBSUB_NAME, PUBSUB_TOPIC, eventJson); err != nil {
@@ -230,30 +226,37 @@ if err := s.APIClient.PublishEvent(ctx, PUBSUB_NAME, PUBSUB_TOPIC, eventJson); e
 
 ```
 
-As we have seen, Dapr provides Application-Level APIs for application developers to use regarding the programming language that they are using. These APIs abstract away the complexities of setting up and managing application infrastructure components, enabling platform teams to have more flexibility to focus on fine-tuning how applications will interact with them without pushing teams to change the application source code. 
+Como hemos visto, Dapr provee API de nivel de aplicación para que las usen los desarrolladores de aplicaciones, sin importar el lenguaje que utilicen.
+Estas API abstraen la complejidad de configurar y administrar componentes de infraestructura de la aplicación, permitiendo que los equipos tengan más flexibilidad para enfocarse en configurar cómo las aplicaciones interactúan con ellas sin que se requieran cambios en el código de la aplicación.
 
-Next, let's talk about feature flags. This topic involves not only developers but also enables product managers and roles closer to the business to decide when certain features should be exposed.
+Ahora, hablemos de feature flags.
+Este tópico involucra no solo a los desarrolladores, sino que permite a los administradores de producto y roles más cercanos a la empresa decidir cuándo y qué características deben ser expuestas.
 
+## Feature Flags para todos
 
-## Feature Flags for everyone
+El proyecto [OpenFeature](https://openfeature.dev/) tiene como objetivo estandarizar cómo consumir Feature Flags desde aplicaciones escritas en diferentes lenguajes.
 
-The [OpenFeature](https://openfeature.dev/) project aims to standardize how to consume Feature Flags from applications written in different languages. 
-
-In this short tutorial, we will look at how the Conference Application `v2.0.0` uses Open Feature and, more specifically, the `flagd` provider to enable feature flags across all application services. For this example, to keep it simple, I've used the `flagd` provider that allows us to define our feature flag configurations inside a Kubernetes `ConfigMap`.
+En este breve tutorial,
+miraremos cómo la aplicación de conferencias `v2.0.0` utiliza Open Feature y,
+más específicamente,
+el proveedor `flagd` para permitir el uso de feature flags en todos los servicios.
+Para este ejemplo, manteniendo la simplicidad, he utilizado el proveedor `flagd` que nos permite definir nuestra configuración de feature flag dentro de un `ConfigMap`de Kubernetes.
 
 ![openfeature](imgs/conference-app-openfeature.png)
 
-In the same way as Dapr APIs, the idea here is to have a consistent experience no matter which provider we have selected. If the platform team wants to switch providers, for example, LaunchDarkly or Split, there will be no need to change how features are fetched or evaluated. The platform team will be able to swap providers to whichever they think is best. 
+De la misma manera que las API de Dapr, la idea aquí es tener una experiencia consistente, sin importar cuál proveedor hemos elegido.
+Si el equipo de plataformas decide cambiar el proveedor, por ejemplo, LaunchDarkly o Split, no hará falta cambiar cómo se obtienen o evalúan los feature flags.
+El equipo de plataformas será capaz de cambiar proveedores a cualquiera que piensen que es el mejor.
+ 
+La versión `v2.0.0` crea un ConfigMap llamado `flag-configuration`que contiene la configuración de feature flags que utilizarán los servicios.
 
-`v2.0.0` created a ConfigMap called `flag-configuration` containing the Feature Flag that the application's services will use. 
-
-You can get the flag configuration json file included in the ConfigMap by running: 
+Puedes obtener el fichero json con la configuración de los feature flags incluido en el ConfigMap ejecutando:
 
 ```shell
 kubectl get cm flag-configuration -o go-template='{{index .data "flag-config.json"}}'
 ```
 
-You should see the following output: 
+Deberías ver algo similar a la siguiente salida:
 
 ```json
 {
@@ -299,18 +302,22 @@ You should see the following output:
 }
 ```
 
-There are three feature flags defined for this example: 
-- `debugEnabled` is a boolean flag that allows us to turn on and off the Debug tab in the back office of the application. This replaces the need for an environment variable that we used in `v1.0.0`. We can turn the debug section on and off without restarting the application frontend container.
-- `callForProposalsEnabled` This boolean flag allows us to disable the **Call for Proposals** section of the application. As conferences have a window to allow potential speakers to submit proposals, when that period is over, this section can be hidden away. Having to release a specific version to just turn off that section would be too complicated to manage, hence having a feature flag for this makes a lot of sense. We can make this change without the need to restart the application frontend container.
-- `eventsEnabled` is an object feature flag, this means that it contains a structure and allows teams to define complex configurations. In this case, I've defined different profiles of flags to configure which service can emit events (Events tab in the application back office). By default all services emit events, but by changing the `defaultVariant` value to `none` we can disable events for all services, without the need to restart any container.
+Existen 3 feature flags definidas para este ejemplo:
 
+- `debugEnabled` es una marca booleana que nos permite habilitar o deshabilitar la sección Debug en la sección Back Office de la aplicación. Esto reemplaza la necesidad de una variable de entorno que utilizábamos en `v1.0.0`. Podemos habilitar o deshabilitar la sección Debug sin reiniciar el contenedor de la aplicación frontend.
+- `callForProposalsEnabled` Es una marca booleana que nos permite deshabilitar la sección **Call for Proposals** de la aplicación. Como las conferencias tienen un período de tiempo para que los potenciales participantes envíen propuestas, cuando este período finaliza, podemos deshabilitar esta sección. Tener que lanzar una versión específica simplemente para habilitar o deshabilitar esa sección sería muy complicado de manejar, por lo tanto, tener una feature flag para ello tiene mucho sentido. Podemos hacer este cambio sin tener que reiniciar el contenedor de la aplicación frontend.
+- `eventsEnabled` es un objeto feature flag, lo que significa que contiene una estructura y permite a los equipos de plataformas definir configuraciones complejas. En este caso, hemos definido distintos perfiles de flags para configurar cual servicio puede emitir eventos (sección Eventos en la sección Back Office de la aplicación). Por defecto todos los servicios emiten eventos, pero cambiando el valor de `defaultVariant` a `none` podemos deshabilitar los eventos para todos los servicios, sin necesidad de reiniciar ningún contenedor.
 
-You can patch the ConfigMap to turn on the debug feature by following these steps. First, fetch the content of the `flag-config.json` file located inside the ConfigMap and store it locally.
+Puedes modificar el ConfigMap para habilitar la feature debug siguiendo estos pasos.
+Primero,
+obtén el contenido del fichero `flag-config.json` localizado dentro del ConfigMap
+y guárdalo localmente.
+
 ```shell
 kubectl get cm flag-configuration -o go-template='{{index .data "flag-config.json"}}' > flag-config.json
 ```
 
-Modify the content of this file, for example turn on the debug flag: 
+Modifica el contenido de este fichero, por ejemplo, activa la flag debug:
 
 ```json
 {
@@ -325,35 +332,44 @@ Modify the content of this file, for example turn on the debug flag:
     },
     ...
 ```
-Then patch the existing `ConfigMap`: 
+Luego, modifica el `ConfigMap` existente:
 
 ```shell
 kubectl create cm flag-configuration --from-file=flag-config.json=flag-config.json --dry-run=client -o yaml | kubectl patch cm flag-configuration --type merge --patch-file /dev/stdin
 ```
 
-After 20 seconds or so, you should see the Debug Tab in the application's back office section
+Después de unos 20 segundos, deberías ver la sección Debug en la sección Back Office de la aplicación.
 
 ![debug feature flag](imgs/feature-flag-debug-tab.png)
 
-You can see that feature flags are now also displayed in this tab. 
+Puedes ver que las feature flags ahora se muestran en esta sección
 
-Now submit a new proposal and approve it. You will see that in the `Events` tab, Events will be displayed. 
+Ahora envía una nueva propuesta y apruébala.
+Verás que se mostrarán los eventos en la sección `Events`.
 
 ![events for approved proposal](imgs/feature-flag-events-for-proposal.png)
 
+Si repites el proceso previo y cambias el valor de `eventsEnabled` a `defaultVariant` a `none`,
+todos los servicios dejarán de emitir eventos.
+Envía una nueva propuesta desde la interfaz de usuario de la aplicación y apruébala,
+luego revisa la sección `Events` para verificar que no se emitieron eventos.
+Recuerda que cuando cambias el `ConfigMap` `flag-configuration`,
+`flagd` necesita esperar alrededor de 10 segundos para refresacar el contenido del ConfigMap.
+Si tienes la sección Debug habilitada puedes refrescar esa pantalla hasta que veas que el valor ha cambiado. 
 
-If you repeat the previous process and change the `eventsEnabled` feature flag to `"defaultVariant": "none"`, all services will stop emitting events. Submit a new proposal from the application user interface and approve it, then check the `Events` tab to validate that no event has been emitted. Remember that when changing the `flag-configuration` ConfigMap, `flagd` needs to wait around 10 seconds to refresh the content of the ConfigMap. If you have the Debug tab enabled you can refresh that screen until you see that the value has changed. 
+**Notemos que esta feature flag es consumida por todos los servicios que evalúan la flag antes de enviar un evento.**
 
-**Notice that this feature flag is being consumed by all services that evaluate the flag before sending any event. **
-
-Finally, if you change the `callForProposalsEnabled` feature flag `"defaultVariant": "off"`, the Call for Proposal menu option will disappear from the application frontend. 
+Finalmente, si cambias la feature flag `callForProposalsEnabled` a `defaultVariant` a `off`, la sección **Call for Proposals** de la aplicación desaparecerá.
 
 ![no call for proposals feature flag](imgs/feature-flag-no-c4p.png)
 
+Mientras seguimos utilizando un `ConfigMap` para almacenar la configuración de feature flags, hemos logrado algunas mejoras importantes que permiten a los equipos ir más rápido.
+Los desarrolladores pueden continuar lanzando nuevas características a sus servicios de aplicación que luego los administradores de producto (o stakeholders) pueden deciidir cuando habilitarlas o deshabilitarlas.
+Los equipos de plataformas pueden definir donde se almacenarán las feature flags (en un servicio de almacenamiento o en el disco local).
+Al usar una especificación estándar, impulsada por una comunidad compuesta de proveedores de feature flags permite a nuestros equipos de desarrollo de aplicaciones hacer uso de las feature flags sin definir todos los aspectos técnicos requeridos para implementar estos mecanismos internamente. 
 
-While we are still using a `ConfigMap` to store the feature flags configurations we have achieved some important improvements that enable teams to go faster. Developers can keep releasing new features to their application services that then product managers (or stakeholders) can decide when to enable/disable. Platform Teams can define where the feature flags will be stored (a managed service or local storage). By using a standard specification driven by a community composed of Feature Flag vendors enables our application development teams to make use of feature flags without defining all the technical aspects required to implement these mechanisms in-house. 
+En este ejemplo, no hemos utilizado características más evanzadas para evaluar feature flags como [evaluación basada en el contexto](https://openfeature.dev/docs/reference/concepts/evaluation-context#providing-evaluation-context), que puede usar, por ejemplo, la geolocalización de un usuario para proveer valores diferentes para las mismas feature flags, o [tarjetas de evaluación](https://openfeature.dev/docs/reference/concepts/evaluation-context#targeting-key). Depende del lector el profundizar en las capacidades de OpenFeature así como qué otros [proveedores de feature flags](https://openfeature.dev/docs/reference/concepts/provider) están disponibles.
 
-In this example, we haven't used more advanced features to evaluate feature flags like [context-based evaluations](https://openfeature.dev/docs/reference/concepts/evaluation-context#providing-evaluation-context), which can use for example, the geo-location of the user to provide different values for the same feature flag, or [targetting keys](https://openfeature.dev/docs/reference/concepts/evaluation-context#targeting-key). It is up to the reader to go deeper into OpenFeature capabilities as well as which other [Open Feature flag providers](https://openfeature.dev/docs/reference/concepts/provider) are available.  
 
 ## Limpieza
 
@@ -375,9 +391,9 @@ La implementación actual solo elimina la entrada del menú "Convocatoria de Pro
 
 ## Resumen y Contribuir
 
-En este tutorial, hemos explorado las API a nivel de aplicación utilizando Dapr y las banderas de características utilizando OpenFeature.
+En este tutorial, hemos explorado las API a nivel de aplicación utilizando Dapr y las feature flags utilizando OpenFeature.
 Las API a nivel de aplicación, como las expuestas por los Componentes de Dapr, pueden ser aprovechadas por los equipos de desarrollo de aplicaciones, ya que la mayoría de las aplicaciones estarán interesadas en almacenar y leer estado, emitir y consumir eventos, y políticas de resiliencia para comunicaciones de servicio a servicio.
-Las banderas de características también pueden ayudar a acelerar el proceso de desarrollo y lanzamiento al permitir que los desarrolladores sigan lanzando funciones mientras que otros stakeholders deciden cuándo habilitar o deshabilitar estas funciones.
+Las feature flags también pueden ayudar a acelerar el proceso de desarrollo y lanzamiento al permitir que los desarrolladores sigan lanzando funciones mientras que otros stakeholders deciden cuándo habilitar o deshabilitar estas funciones.
 
 ¿Quieres mejorar este tutorial?
 Crea un Issue, envíame un mensaje en [Twitter](https://twitter.com/salaboy) o envía un [Pull Request](https://github.com/salaboy/platforms-on-k8s/pulls).

--- a/chapter-7/README-es.md
+++ b/chapter-7/README-es.md
@@ -349,11 +349,14 @@ kind delete clusters dev
 ```
 
 
-## Next Steps
+## Próximos Pasos
 
-A natural next step would be to run `v2.0.0` against infrastructure provisioned by Crossplane, as we did in Chapter 5. This can be managed by our Platform Walking skeleton, which will be in charge of configuring the Conference Application Helm chart to connect to the provisioned infrastructure by wiring Kubernetes resources together. If you are interested in this topic, I've written a blog post about why tools like Crossplane and Dapr are meant to work together: [https://blog.crossplane.io/crossplane-and-dapr/](https://blog.crossplane.io/crossplane-and-dapr/).
+Un siguiente paso natural sería ejecutar la versión `v2.0.0` en la infraestructura provisionada por Crossplane, como hicimos en el Capítulo 5.
+Esto puede ser gestionado por nuestro esqueleto de plataforma, que se encargará de configurar el gráfico de Helm de la Aplicación de Conferencias para conectarse a la infraestructura provisionada, conectando los recursos de Kubernetes entre sí.
+Si te interesa este tema, he escrito un artículo sobre por qué herramientas como Crossplane y Dapr están destinadas a trabajar juntas: [https://blog.crossplane.io/crossplane-and-dapr/](https://blog.crossplane.io/crossplane-and-dapr/).
 
-Another simple but very useful extension to the application code would be to make sure that the Call for Proposals Service reads the `callForProposalsEnabled` feature flag and returns meaningful errors when this feature is disabled. The current implementation only removes the `Call for Proposals` menu entry, meaning that if you send a `curl` request to the APIs, the functionality should still work. 
+Otra extensión simple, pero muy útil del código de la aplicación sería asegurarse de que el Servicio de Convocatoria de Propuestas lea la bandera de características `callForProposalsEnabled` y devuelva errores significativos cuando esta función esté deshabilitada.
+La implementación actual solo elimina la entrada del menú "Convocatoria de Propuestas", lo que significa que si envías una solicitud `curl` a las APIs, la funcionalidad aún debería funcionar.
 
 ## Sum up and Contribute
 

--- a/chapter-7/README-es.md
+++ b/chapter-7/README-es.md
@@ -17,11 +17,12 @@ encontrarás todos los cambios requeridos para esta nueva versión en la rama `v
 Puedes comparar las diferencias entre las ramas aquí](https://github.com/salaboy/platforms-on-k8s/compare/v2.0.0).
 
 
-# Installation
+# Instalación
 
-You need a Kubernetes Cluster to install [Dapr](https://dapr.io) and `flagd` an [OpenFeature](https://openfeature.dev/) Provider. You can create one using Kubernetes KinD as we did in [Chapter 2](https://github.com/salaboy/platforms-on-k8s/blob/main/chapter-2/README.md#creating-a-local-cluster-with-kubernetes-kind)
+Necesitas un Clúster de Kubernetes para instalar [Dapr](https://dapr.io) y `flagd`, un proveedor de [OpenFeature](https://openfeature.dev/).
+Puedes crear uno utilizando Kubernetes KinD como vimos en el [Capítulo 2](../chapter-2/README-es.md#creando-un-clúster-local-con-kubernetes-kind)
 
-Then you can install Dapr into the cluster by running: 
+Luego puedes instalar Dapr en el clúster ejecutando:
 ```shell
 helm repo add dapr https://dapr.github.io/helm-charts/
 helm repo update
@@ -33,22 +34,23 @@ helm upgrade --install dapr dapr/dapr \
 
 ```
 
-Once Dapr is installed, we can install our Dapr-Enabled and FeatureFlag-Enabled versions of the application `v2.0.0`.
+Una vez que Dapr está instalado, podemos instalar nuestra versión `v2.0.0` de la aplicación habilitada con Dapr y FeatureFlag.
 
-# Running v2.0.0
-
-Now you can install v2.0.0 of the application by running: 
+# Ejecutando v2.0.0
+Ahora puedes instalar la versión `v2.0.0` de la aplicación ejecutando:
 
 ```shell
 helm install conference oci://docker.io/salaboy/conference-app --version v2.0.0
 ```
 
-This version of the Helm Chart installs the same application infrastructure as version `v1.0.0` (PostgreSQL, Redis, and Kafka). Services now interact with Redis and Kafka are now using Dapr APIs. This application version also adds OpenFeature Feature Flags using `flagd`.
+Esta versión del chart de Helm instala la misma infraestructura de la aplicación que la versión
+`v1.0.0` (PostgreSQL, Redis, y Kafka).
+Los servicios que interactúan con Redis y Kafka ahora usan las API de Dapr.
+Esta versión de la aplicación también añade banderas de características OpenFeature utilizando `flagd`.
 
-# Application Level APIs with Dapr
+# API a nivel de aplicación con Dapr
 
-In version `v2.0.0`, if you list the Application pods now, you will see that each service (agenda, c4p, frontend, and notifications) has a Dapr Sidecar (`daprd`) running alongside the service container (READY 2/2): 
-
+En la versión `v2.0.0`, si haces un listado de pods de la Aplicación, verás que cada servicio (agenda, c4p, frontend, y notificaciones) tiene un Dapr Sidecar (`daprd`) corriendo junto con el contenedor de servicio (READY 2/2):
 ```shell
 > kubectl get pods
 NAME                                                           READY   STATUS    RESTARTS      AGE
@@ -62,15 +64,16 @@ conference-redis-master-0                                      1/1     Running  
 flagd-6bbdc5d999-c42wk                                         1/1     Running   0             74s
 ```
 
-Notice the `flagd` container also running. We will cover this in the next section.
+Notemos que el contenedor `flagd` también se está ejecutando.
+Cubriremos esto en la siguiente sección.
 
-From the Dapr perspective the application looks like this: 
+Desde la perspectiva de Dapr, la aplicación se ve así: 
 
 ![conference-app-with-dapr](imgs/conference-app-with-dapr.png)
 
-The Dapr Sidecar exposes the Dapr Components APIs to enable the application to interact with   Statestore (Redis) and PubSub (Kafka) APIs. 
+El sidecar de Dapr exponer las API de los componentes Dapr para que los servicios puedan interactuar con las API de Statestore (Redis) y PubSub (Kafka).
 
-You can list Dapr Components by running: 
+Puedes listar los componentes Dapr ejecutando:
 
 ```shell
 > kubectl get components
@@ -79,7 +82,7 @@ conference-agenda-service-statestore   30m
 conference-conference-pubsub           30m
 ```
 
-You can describe each component to see its configurations:
+Puedes describir cada componente para ver sus configuraciones:
 ```shell
 > kubectl describe component conference-agenda-service-statestore
 Name:         conference-agenda-service-statestore
@@ -112,10 +115,9 @@ Events:      <none>
 
 ```
 
-You can see that the Statestore component is connecting to the Redis instance exposed by this service name `conference-redis-master.default.svc.cluster.local` and using the `conference-redis` secret to obtain the password to connect.
+Puedes observar que el componente Statestore conecta la instancia de Redis expuesta por este nombre de servicio`conference-redis-master.default.svc.cluster.local` usando el secreto `conference-redis` para obtener la contraseña para conectarse.
 
-Similarly, the PubSub Dapr Component that is connecting to Kafka: 
-
+De forma similar, el componente Dapr PubSub conecta con Kafka:
 ```shell
 kubectl describe component conference-conference-pubsub 
 Name:         conference-conference-pubsub
@@ -141,7 +143,7 @@ Spec:
 Events:     <none>
 ```
 
-The final piece of the puzzle that allows the Frontend service to receive events that are submitted to the PubSub component is the following Dapr Subscription: 
+La pieza final del rompecabezas que permite al servicio Frontend recibir eventos que se envían al componente Pubsub es la siguiente suscripción de Dapr: 
 
 ```shell
 > kubectl get subscription
@@ -149,7 +151,7 @@ NAME                               AGE
 conference-frontend-subscritpion   39m
 ```
 
-You can also describe this resource to see its configurations: 
+También puedes describir este recurso para mirar sus configuraciones:
 ```shell
 > kubectl describe subscription conference-frontend-subscritpion
 Name:         conference-frontend-subscritpion
@@ -176,9 +178,14 @@ Spec:
 Events:       <none>
 ```
 
-As you can see, this subscription forwards events to the route `/api/new-events/` for the Dapr applications listed in the `Scopes` section, only the `frontend` application. The Frontend Application only needs to expose the `/api/new-events/` endpoint to receive events, in this case the Dapr Sidecar (`daprd`) waits for incoming messages on the PubSub component called `conference-conference-pubsub` and forwards all messages to the Application Endpoint. 
+Como puedes ver,
+esta suscripción reenvía los eventos a la ruta `/api/new-events/` para que las aplicaciones Daps listadas
+en la sección `Scopes`, solo la aplicación `frontend`.
+Solo la aplicación Frontend necesita exponer el endpoint para recibir eventos,
+en este caso el sidecar de Dapr (`daprd`)
+espera los mensajes entrantes en el componente PubSub llamado `conference-conference-pubsub` y reenvía todos los mensajes al endpoint de la Aplicación.
 
-This version of the application removes application dependencies such as the Kafka Client from all services and the Redis Client from the Agenda Service. 
+Esta versión de la aplicación eliminar dependencias de la aplicación tales como el cliente de Kafka de todos los servicios y el cliente de Redis del servicio de Agenda.
 
 
 ![services without deps](imgs/conference-app-dapr-no-deps.png)

--- a/chapter-7/README-es.md
+++ b/chapter-7/README-es.md
@@ -351,16 +351,19 @@ kind delete clusters dev
 
 ## Próximos Pasos
 
-Un siguiente paso natural sería ejecutar la versión `v2.0.0` en la infraestructura provisionada por Crossplane, como hicimos en el Capítulo 5.
+Un siguiente paso natural sería ejecutar la versión `v2.0.0` en la infraestructura provisionada por Crossplane, como hicimos en el [Capítulo 5](../chapter-5/README-es.md).
 Esto puede ser gestionado por nuestro esqueleto de plataforma, que se encargará de configurar el gráfico de Helm de la Aplicación de Conferencias para conectarse a la infraestructura provisionada, conectando los recursos de Kubernetes entre sí.
 Si te interesa este tema, he escrito un artículo sobre por qué herramientas como Crossplane y Dapr están destinadas a trabajar juntas: [https://blog.crossplane.io/crossplane-and-dapr/](https://blog.crossplane.io/crossplane-and-dapr/).
 
 Otra extensión simple, pero muy útil del código de la aplicación sería asegurarse de que el Servicio de Convocatoria de Propuestas lea la bandera de características `callForProposalsEnabled` y devuelva errores significativos cuando esta función esté deshabilitada.
-La implementación actual solo elimina la entrada del menú "Convocatoria de Propuestas", lo que significa que si envías una solicitud `curl` a las APIs, la funcionalidad aún debería funcionar.
+La implementación actual solo elimina la entrada del menú "Convocatoria de Propuestas", lo que significa que si envías una solicitud `curl` a las API, la funcionalidad aún debería funcionar.
 
-## Sum up and Contribute
+## Resumen y Contribuir
 
-In this tutorial, we have looked into Application-level APIs using Dapr and Feature Flags using OpenFeature. Application-level APIs like the ones exposed by Dapr Components can be leveraged by application development teams, as most applications will be interested in storing and reading state, emitting, and consuming events and resiliency policies for service-to-service communications. Feature Flags can also help to speed up the development and release process by enabling developers to keep releasing features while other stakeholders can decide when these features are enabled or disabled. 
+En este tutorial, hemos explorado las API a nivel de aplicación utilizando Dapr y las banderas de características utilizando OpenFeature.
+Las API a nivel de aplicación, como las expuestas por los Componentes de Dapr, pueden ser aprovechadas por los equipos de desarrollo de aplicaciones, ya que la mayoría de las aplicaciones estarán interesadas en almacenar y leer estado, emitir y consumir eventos, y políticas de resiliencia para comunicaciones de servicio a servicio.
+Las banderas de características también pueden ayudar a acelerar el proceso de desarrollo y lanzamiento al permitir que los desarrolladores sigan lanzando funciones mientras que otros stakeholders deciden cuándo habilitar o deshabilitar estas funciones.
 
+¿Quieres mejorar este tutorial?
+Crea un Issue, envíame un mensaje en [Twitter](https://twitter.com/salaboy) o envía un [Pull Request](https://github.com/salaboy/platforms-on-k8s/pulls).
 
-Do you want to improve this tutorial? Create an issue, drop me a message on [Twitter](https://twitter.com/salaboy), or send a Pull Request.

--- a/chapter-7/README-es.md
+++ b/chapter-7/README-es.md
@@ -115,7 +115,7 @@ Events:      <none>
 
 ```
 
-Puedes observar que el componente Statestore conecta la instancia de Redis expuesta por este nombre de servicio`conference-redis-master.default.svc.cluster.local` usando el secreto `conference-redis` para obtener la contraseña para conectarse.
+Puedes observar que el componente Statestore se conecta con la instancia de Redis expuesta por este nombre de servicio`conference-redis-master.default.svc.cluster.local` usando el secreto `conference-redis` para obtener la contraseña para conectarse.
 
 De forma similar, el componente Dapr PubSub conecta con Kafka:
 ```shell
@@ -190,10 +190,16 @@ Esta versión de la aplicación eliminar dependencias de la aplicación tales co
 
 ![services without deps](imgs/conference-app-dapr-no-deps.png)
 
-Besides removing the dependencies and making these containers smaller, by consuming the Dapr Components API, we enable the platform team to define how these components will be configured and against which infrastructural components. Configuring the same application to use Google Cloud Platform managed services such as [Google PubSub](https://cloud.google.com/pubsub) or the [MemoryStore databases](https://cloud.google.com/memorystore) will not require any changes in the application code or adding any new dependencies, just new Dapr Component configurations.
+Ademas de eliminar las dependencias y hacer los contenedores más pequeños,
+al consumir la API de los componentes Dapr, permitimos que el equipo de plataforma defina cómo se configurar esos componentes y sobre qué infraestructura.
+Configurar la misma aplicación para usar servicios administrados de Google Cloud Platform como [Google PubSub](https://cloud.google.com/pubsub) o la [MemoryStore databases](https://cloud.google.com/memorystore) no requiere cambios en el código de la aplicación o agregar nuevas dependencias, solo se necesitan nuevas configuraciones de componentes de Dapr.
 
 ![in gcp](imgs/conference-app-dapr-and-gcp.png)
 
+Finalmente, ya que todo se trata de permitir que los desarrolladores utilicen las API a nivel de aplicación, miremos cómo se ve desde la perspectiva del servicio.
+Como los servicios están escritos en Go, he decidido añadir la SDK de Dapr para Go (que es opcional).
+
+Cuando el servicio de Agenda quiere almacenar o leer datos del componente Statestore, puede utilizar el cliente Dapr para realizar estar operaciones, por ejemplo 
 
 Finally, because this is all about enabling developers with Application Level APIs, let's look at how this looks from the application's service perspective. Because the services are written in Go, I've decided to add the Dapr Go SDK (which is optional). 
 

--- a/chapter-7/README-es.md
+++ b/chapter-7/README-es.md
@@ -1,0 +1,363 @@
+# Capítulo 7 :: Shared Applications Concerns
+
+---
+_🌍 Available in_: [English](README.md) | [中文 (Chinese)](README-zh.md) | [日本語 (Japanese)](README-ja.md) | [Español](README-es.md)
+
+> **Nota:** Presentado por la fantástica comunidad
+> de [ 🌟 contribuidores](https://github.com/salaboy/platforms-on-k8s/graphs/contributors) cloud-native!
+
+---
+
+In this step-by-step tutorial, we will look into using [Dapr](https://dapr.io) to provide Application-level APIs to solve everyday challenges that most Distributed Applications will face. 
+
+Then we will look at [OpenFeature](https://openfeature.dev), a project that aims to standardize Feature Flags so development teams can keep releasing new features and stakeholders can decide when to enable/disable these features for their customers. 
+
+Because both projects are focused on providing developers with new APIs and tools to use inside their service's code, we will deploy a new version of the application (`v2.0.0`). You can find all the changes required for this new version in the `v2.0.0` of this repository. [You can also compare the differences between the branches here](https://github.com/salaboy/platforms-on-k8s/compare/v2.0.0).
+
+
+# Installation
+
+You need a Kubernetes Cluster to install [Dapr](https://dapr.io) and `flagd` an [OpenFeature](https://openfeature.dev/) Provider. You can create one using Kubernetes KinD as we did in [Chapter 2](https://github.com/salaboy/platforms-on-k8s/blob/main/chapter-2/README.md#creating-a-local-cluster-with-kubernetes-kind)
+
+Then you can install Dapr into the cluster by running: 
+```shell
+helm repo add dapr https://dapr.github.io/helm-charts/
+helm repo update
+helm upgrade --install dapr dapr/dapr \
+--version=1.11.0 \
+--namespace dapr-system \
+--create-namespace \
+--wait
+
+```
+
+Once Dapr is installed, we can install our Dapr-Enabled and FeatureFlag-Enabled versions of the application `v2.0.0`.
+
+# Running v2.0.0
+
+Now you can install v2.0.0 of the application by running: 
+
+```shell
+helm install conference oci://docker.io/salaboy/conference-app --version v2.0.0
+```
+
+This version of the Helm Chart installs the same application infrastructure as version `v1.0.0` (PostgreSQL, Redis, and Kafka). Services now interact with Redis and Kafka are now using Dapr APIs. This application version also adds OpenFeature Feature Flags using `flagd`.
+
+# Application Level APIs with Dapr
+
+In version `v2.0.0`, if you list the Application pods now, you will see that each service (agenda, c4p, frontend, and notifications) has a Dapr Sidecar (`daprd`) running alongside the service container (READY 2/2): 
+
+```shell
+> kubectl get pods
+NAME                                                           READY   STATUS    RESTARTS      AGE
+conference-agenda-service-deployment-5dd4bf67b-qkctd           2/2     Running   7 (7s ago)    74s
+conference-c4p-service-deployment-57b5985757-tdqg4             2/2     Running   6 (19s ago)   74s
+conference-frontend-deployment-69d9b479b7-th44h                2/2     Running   2 (68s ago)   74s
+conference-kafka-0                                             1/1     Running   0             74s
+conference-notifications-service-deployment-7b6cbf965d-2pdkh   2/2     Running   6 (42s ago)   74s
+conference-postgresql-0                                        1/1     Running   0             74s
+conference-redis-master-0                                      1/1     Running   0             74s
+flagd-6bbdc5d999-c42wk                                         1/1     Running   0             74s
+```
+
+Notice the `flagd` container also running. We will cover this in the next section.
+
+From the Dapr perspective the application looks like this: 
+
+![conference-app-with-dapr](imgs/conference-app-with-dapr.png)
+
+The Dapr Sidecar exposes the Dapr Components APIs to enable the application to interact with   Statestore (Redis) and PubSub (Kafka) APIs. 
+
+You can list Dapr Components by running: 
+
+```shell
+> kubectl get components
+NAME                                   AGE
+conference-agenda-service-statestore   30m
+conference-conference-pubsub           30m
+```
+
+You can describe each component to see its configurations:
+```shell
+> kubectl describe component conference-agenda-service-statestore
+Name:         conference-agenda-service-statestore
+Namespace:    default
+Labels:       app.kubernetes.io/managed-by=Helm
+Annotations:  meta.helm.sh/release-name: conference
+              meta.helm.sh/release-namespace: default
+API Version:  dapr.io/v1alpha1
+Auth:
+  Secret Store:  kubernetes
+Kind:            Component
+Metadata:
+  Creation Timestamp:  2023-07-28T08:26:55Z
+  Generation:          1
+  Resource Version:    4076
+  UID:                 b4674825-d298-4ee3-8244-a13cdef8d530
+Spec:
+  Metadata:
+    Name:   keyPrefix
+    Value:  name
+    Name:   redisHost
+    Value:  conference-redis-master.default.svc.cluster.local:6379
+    Name:   redisPassword
+    Secret Key Ref:
+      Key:   redis-password
+      Name:  conference-redis
+  Type:      state.redis
+  Version:   v1
+Events:      <none>
+
+```
+
+You can see that the Statestore component is connecting to the Redis instance exposed by this service name `conference-redis-master.default.svc.cluster.local` and using the `conference-redis` secret to obtain the password to connect.
+
+Similarly, the PubSub Dapr Component that is connecting to Kafka: 
+
+```shell
+kubectl describe component conference-conference-pubsub 
+Name:         conference-conference-pubsub
+Namespace:    default
+Labels:       app.kubernetes.io/managed-by=Helm
+Annotations:  meta.helm.sh/release-name: conference
+              meta.helm.sh/release-namespace: default
+API Version:  dapr.io/v1alpha1
+Kind:         Component
+Metadata:
+  Creation Timestamp:  2023-07-28T08:26:55Z
+  Generation:          1
+  Resource Version:    4086
+  UID:                 e145bc49-18ff-4390-ad15-dcd9a4275479
+Spec:
+  Metadata:
+    Name:   brokers
+    Value:  conference-kafka.default.svc.cluster.local:9092
+    Name:   authType
+    Value:  none
+  Type:     pubsub.kafka
+  Version:  v1
+Events:     <none>
+```
+
+The final piece of the puzzle that allows the Frontend service to receive events that are submitted to the PubSub component is the following Dapr Subscription: 
+
+```shell
+> kubectl get subscription
+NAME                               AGE
+conference-frontend-subscritpion   39m
+```
+
+You can also describe this resource to see its configurations: 
+```shell
+> kubectl describe subscription conference-frontend-subscritpion
+Name:         conference-frontend-subscritpion
+Namespace:    default
+Labels:       app.kubernetes.io/managed-by=Helm
+Annotations:  meta.helm.sh/release-name: conference
+              meta.helm.sh/release-namespace: default
+API Version:  dapr.io/v2alpha1
+Kind:         Subscription
+Metadata:
+  Creation Timestamp:  2023-07-28T08:26:55Z
+  Generation:          1
+  Resource Version:    4102
+  UID:                 9f748cb0-125a-4848-bd39-f84e37e41282
+Scopes:
+  frontend
+Spec:
+  Bulk Subscribe:
+    Enabled:   false
+  Pubsubname:  conference-conference-pubsub
+  Routes:
+    Default:  /api/new-events/
+  Topic:      events-topic
+Events:       <none>
+```
+
+As you can see, this subscription forwards events to the route `/api/new-events/` for the Dapr applications listed in the `Scopes` section, only the `frontend` application. The Frontend Application only needs to expose the `/api/new-events/` endpoint to receive events, in this case the Dapr Sidecar (`daprd`) waits for incoming messages on the PubSub component called `conference-conference-pubsub` and forwards all messages to the Application Endpoint. 
+
+This version of the application removes application dependencies such as the Kafka Client from all services and the Redis Client from the Agenda Service. 
+
+
+![services without deps](imgs/conference-app-dapr-no-deps.png)
+
+Besides removing the dependencies and making these containers smaller, by consuming the Dapr Components API, we enable the platform team to define how these components will be configured and against which infrastructural components. Configuring the same application to use Google Cloud Platform managed services such as [Google PubSub](https://cloud.google.com/pubsub) or the [MemoryStore databases](https://cloud.google.com/memorystore) will not require any changes in the application code or adding any new dependencies, just new Dapr Component configurations.
+
+![in gcp](imgs/conference-app-dapr-and-gcp.png)
+
+
+Finally, because this is all about enabling developers with Application Level APIs, let's look at how this looks from the application's service perspective. Because the services are written in Go, I've decided to add the Dapr Go SDK (which is optional). 
+
+When the Agenda Service wants to store or read data from the Dapr Statestore component, it can use the Dapr Client to perform these operations, for example [reading values from the Statestore looks like this](https://github.com/salaboy/platforms-on-k8s/blob/v2.0.0/conference-application/agenda-service/agenda-service.go#L136C2-L136C116): 
+
+```golang
+agendaItemsStateItem, err := s.APIClient.GetState(ctx, STATESTORE_NAME, fmt.Sprintf("%s-%s", TENANT_ID, KEY), nil)
+```
+
+The `APIClient` reference is just a [Dapr Client instance, which was initialized here](https://github.com/salaboy/platforms-on-k8s/blob/v2.0.0/conference-application/agenda-service/agenda-service.go#L397)
+
+All the application needs to know is the Statestore name (`STATESTORE_NAME`) and the key (`KEY`) to locate the data that wants to be retrieved.
+
+When the application wants to [store state into the Statestore it looks like this](https://github.com/salaboy/platforms-on-k8s/blob/v2.0.0/conference-application/agenda-service/agenda-service.go#L197C2-L199C3):
+
+```golang
+if err := s.APIClient.SaveState(ctx, STATESTORE_NAME, fmt.Sprintf("%s-%s", TENANT_ID, KEY), jsonData, nil); err != nil {
+		...
+}
+```  
+
+Finally, if the application code wants to [publish a new event to the PubSub component](https://github.com/salaboy/platforms-on-k8s/blob/v2.0.0/conference-application/agenda-service/agenda-service.go#L225), it will look like this: 
+
+```golang
+if err := s.APIClient.PublishEvent(ctx, PUBSUB_NAME, PUBSUB_TOPIC, eventJson); err != nil {
+			...
+}
+
+```
+
+As we have seen, Dapr provides Application-Level APIs for application developers to use regarding the programming language that they are using. These APIs abstract away the complexities of setting up and managing application infrastructure components, enabling platform teams to have more flexibility to focus on fine-tuning how applications will interact with them without pushing teams to change the application source code. 
+
+Next, let's talk about feature flags. This topic involves not only developers but also enables product managers and roles closer to the business to decide when certain features should be exposed.
+
+
+## Feature Flags for everyone
+
+The [OpenFeature](https://openfeature.dev/) project aims to standardize how to consume Feature Flags from applications written in different languages. 
+
+In this short tutorial, we will look at how the Conference Application `v2.0.0` uses Open Feature and, more specifically, the `flagd` provider to enable feature flags across all application services. For this example, to keep it simple, I've used the `flagd` provider that allows us to define our feature flag configurations inside a Kubernetes `ConfigMap`.
+
+![openfeature](imgs/conference-app-openfeature.png)
+
+In the same way as Dapr APIs, the idea here is to have a consistent experience no matter which provider we have selected. If the platform team wants to switch providers, for example, LaunchDarkly or Split, there will be no need to change how features are fetched or evaluated. The platform team will be able to swap providers to whichever they think is best. 
+
+`v2.0.0` created a ConfigMap called `flag-configuration` containing the Feature Flag that the application's services will use. 
+
+You can get the flag configuration json file included in the ConfigMap by running: 
+
+```shell
+kubectl get cm flag-configuration -o go-template='{{index .data "flag-config.json"}}'
+```
+
+You should see the following output: 
+
+```json
+{
+  "flags": {
+    "debugEnabled": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "off"
+    },
+    "callForProposalsEnabled": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "on"  
+    },
+    "eventsEnabled": {
+      "state": "ENABLED",
+      "variants": {
+        "all": {
+          "agenda-service": true,
+          "notifications-service": true,
+          "c4p-service": true
+        },
+        "decisions-only": {
+          "agenda-service": false,
+          "notifications-service": false,
+          "c4p-service": true
+        },
+        "none": {
+          "agenda-service": false,
+          "notifications-service": false,
+          "c4p-service": false
+        }
+      },
+      "defaultVariant": "all"
+    }
+  }
+}
+```
+
+There are three feature flags defined for this example: 
+- `debugEnabled` is a boolean flag that allows us to turn on and off the Debug tab in the back office of the application. This replaces the need for an environment variable that we used in `v1.0.0`. We can turn the debug section on and off without restarting the application frontend container.
+- `callForProposalsEnabled` This boolean flag allows us to disable the **Call for Proposals** section of the application. As conferences have a window to allow potential speakers to submit proposals, when that period is over, this section can be hidden away. Having to release a specific version to just turn off that section would be too complicated to manage, hence having a feature flag for this makes a lot of sense. We can make this change without the need to restart the application frontend container.
+- `eventsEnabled` is an object feature flag, this means that it contains a structure and allows teams to define complex configurations. In this case, I've defined different profiles of flags to configure which service can emit events (Events tab in the application back office). By default all services emit events, but by changing the `defaultVariant` value to `none` we can disable events for all services, without the need to restart any container.
+
+
+You can patch the ConfigMap to turn on the debug feature by following these steps. First, fetch the content of the `flag-config.json` file located inside the ConfigMap and store it locally.
+```shell
+kubectl get cm flag-configuration -o go-template='{{index .data "flag-config.json"}}' > flag-config.json
+```
+
+Modify the content of this file, for example turn on the debug flag: 
+
+```json
+{
+  "flags": {
+    "debugEnabled": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+    **"defaultVariant": "on"**
+    },
+    ...
+```
+Then patch the existing `ConfigMap`: 
+
+```shell
+kubectl create cm flag-configuration --from-file=flag-config.json=flag-config.json --dry-run=client -o yaml | kubectl patch cm flag-configuration --type merge --patch-file /dev/stdin
+```
+
+After 20 seconds or so, you should see the Debug Tab in the application's back office section
+
+![debug feature flag](imgs/feature-flag-debug-tab.png)
+
+You can see that feature flags are now also displayed in this tab. 
+
+Now submit a new proposal and approve it. You will see that in the `Events` tab, Events will be displayed. 
+
+![events for approved proposal](imgs/feature-flag-events-for-proposal.png)
+
+
+If you repeat the previous process and change the `eventsEnabled` feature flag to `"defaultVariant": "none"`, all services will stop emitting events. Submit a new proposal from the application user interface and approve it, then check the `Events` tab to validate that no event has been emitted. Remember that when changing the `flag-configuration` ConfigMap, `flagd` needs to wait around 10 seconds to refresh the content of the ConfigMap. If you have the Debug tab enabled you can refresh that screen until you see that the value has changed. 
+
+**Notice that this feature flag is being consumed by all services that evaluate the flag before sending any event. **
+
+Finally, if you change the `callForProposalsEnabled` feature flag `"defaultVariant": "off"`, the Call for Proposal menu option will disappear from the application frontend. 
+
+![no call for proposals feature flag](imgs/feature-flag-no-c4p.png)
+
+
+While we are still using a `ConfigMap` to store the feature flags configurations we have achieved some important improvements that enable teams to go faster. Developers can keep releasing new features to their application services that then product managers (or stakeholders) can decide when to enable/disable. Platform Teams can define where the feature flags will be stored (a managed service or local storage). By using a standard specification driven by a community composed of Feature Flag vendors enables our application development teams to make use of feature flags without defining all the technical aspects required to implement these mechanisms in-house. 
+
+In this example, we haven't used more advanced features to evaluate feature flags like [context-based evaluations](https://openfeature.dev/docs/reference/concepts/evaluation-context#providing-evaluation-context), which can use for example, the geo-location of the user to provide different values for the same feature flag, or [targetting keys](https://openfeature.dev/docs/reference/concepts/evaluation-context#targeting-key). It is up to the reader to go deeper into OpenFeature capabilities as well as which other [Open Feature flag providers](https://openfeature.dev/docs/reference/concepts/provider) are available.  
+
+## Limpieza
+
+Si quieres eliminar el Cluster KinD creado para este tutorial, ejecuta:
+
+```shell
+kind delete clusters dev
+```
+
+
+## Next Steps
+
+A natural next step would be to run `v2.0.0` against infrastructure provisioned by Crossplane, as we did in Chapter 5. This can be managed by our Platform Walking skeleton, which will be in charge of configuring the Conference Application Helm chart to connect to the provisioned infrastructure by wiring Kubernetes resources together. If you are interested in this topic, I've written a blog post about why tools like Crossplane and Dapr are meant to work together: [https://blog.crossplane.io/crossplane-and-dapr/](https://blog.crossplane.io/crossplane-and-dapr/).
+
+Another simple but very useful extension to the application code would be to make sure that the Call for Proposals Service reads the `callForProposalsEnabled` feature flag and returns meaningful errors when this feature is disabled. The current implementation only removes the `Call for Proposals` menu entry, meaning that if you send a `curl` request to the APIs, the functionality should still work. 
+
+## Sum up and Contribute
+
+In this tutorial, we have looked into Application-level APIs using Dapr and Feature Flags using OpenFeature. Application-level APIs like the ones exposed by Dapr Components can be leveraged by application development teams, as most applications will be interested in storing and reading state, emitting, and consuming events and resiliency policies for service-to-service communications. Feature Flags can also help to speed up the development and release process by enabling developers to keep releasing features while other stakeholders can decide when these features are enabled or disabled. 
+
+
+Do you want to improve this tutorial? Create an issue, drop me a message on [Twitter](https://twitter.com/salaboy), or send a Pull Request.


### PR DESCRIPTION
# Changes

Including Spanish translation for chapter 7.

I found out that in Spanish, you shouldn't include a final s for acronyms, as we are used to reading in other languages. That's the reason the APIs are translated in Spanish as “las API”. [More information here](https://www.fundeu.es/recomendacion/siglas-y-acronimos-claves-de-redaccion/#:~:text=El%20plural%20de%20las%20siglas,las%20ONGs%20ni%20las%20ONG's.)

I'm not sure whether to translate, or not, the term “feature flag”. In affirmative case, please provide a proper translation and I'll update the document. The Same thing goes for “chart” in Helm chart.

related to #27 