### PR TITLE
fix(v2.0.0): delete namespace attribute

### DIFF
--- a/conference-application/helm/conference-app/templates/openfeature.yaml
+++ b/conference-application/helm/conference-app/templates/openfeature.yaml
@@ -44,7 +44,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: flag-configuration
-  namespace: default
 data:
   flag-config.json: |
     {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

🐛  I think namespace attribute does not be needed in helm template. because we can specify the namespace at helm install cmd.
